### PR TITLE
Implicitly add "/** @jsx React.DOM */" when using JSXBundle. Fixes #31

### DIFF
--- a/src/System.Web.Optimization.React/JsxBundle.cs
+++ b/src/System.Web.Optimization.React/JsxBundle.cs
@@ -23,24 +23,24 @@ namespace System.Web.Optimization.React
 		/// </param>
 		public JsxBundle(string virtualPath) : base(virtualPath, GetTransforms())
 		{
-            base.ConcatenationToken = ";" + Environment.NewLine;
+			base.ConcatenationToken = ";" + Environment.NewLine;
 		}
 
-        /// <summary>
-        /// Applies the transformations.
-        /// </summary>
-        /// <returns>The bundle response.</returns>
-        public override BundleResponse ApplyTransforms(BundleContext context, string bundleContent, Collections.Generic.IEnumerable<BundleFile> bundleFiles)
-        {
-            const string pragma = "/** @jsx React.DOM */";
+		/// <summary>
+		/// Applies the transformations.
+		/// </summary>
+		/// <returns>The bundle response.</returns>
+		public override BundleResponse ApplyTransforms(BundleContext context, string bundleContent, Collections.Generic.IEnumerable<BundleFile> bundleFiles)
+        	{
+			const string pragma = "/** @jsx React.DOM */";
 
-            if (!bundleContent.TrimStart().StartsWith(pragma))
-            {
-                bundleContent = pragma + bundleContent;
-            }
+			if (!bundleContent.TrimStart().StartsWith(pragma))
+			{
+				bundleContent = pragma + bundleContent;
+			}
 
-            return base.ApplyTransforms(context, bundleContent, bundleFiles);
-        }
+			return base.ApplyTransforms(context, bundleContent, bundleFiles);
+        	}
 
 		/// <summary>
 		/// Gets the transformations that should be used by the bundle.


### PR DESCRIPTION
Also use the same ConcatenationToken as used in the ScriptBundle class.
