### PR TITLE
Add possibility to set own JsonSerializerSettings in configuration

### DIFF
--- a/src/React.Tests/Core/ReactComponentTest.cs
+++ b/src/React.Tests/Core/ReactComponentTest.cs
@@ -21,7 +21,7 @@ namespace React.Tests.Core
 		{
 			var environment = new Mock<IReactEnvironment>();
 			environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(false);
-			var component = new ReactComponent(environment.Object, "Foo", "container");
+			var component = new ReactComponent(environment.Object, null, "Foo", "container");
 
 			Assert.Throws<ReactInvalidComponentException>(() =>
 			{
@@ -34,8 +34,9 @@ namespace React.Tests.Core
 		{
 			var environment = new Mock<IReactEnvironment>();
 			environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
+			var config = new Mock<IReactSiteConfiguration>();
 
-			var component = new ReactComponent(environment.Object, "Foo", "container")
+			var component = new ReactComponent(environment.Object, config.Object, "Foo", "container")
 			{
 				Props = new { hello = "World" }
 			};
@@ -51,8 +52,9 @@ namespace React.Tests.Core
 			environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
 			environment.Setup(x => x.Execute<string>(@"React.renderToString(Foo({""hello"":""World""}))"))
 				.Returns("[HTML]");
+			var config = new Mock<IReactSiteConfiguration>();
 
-			var component = new ReactComponent(environment.Object, "Foo", "container")
+			var component = new ReactComponent(environment.Object, config.Object, "Foo", "container")
 			{
 				Props = new { hello = "World" }
 			};
@@ -65,8 +67,9 @@ namespace React.Tests.Core
 		public void RenderJavaScriptShouldCallRenderComponent()
 		{
 			var environment = new Mock<IReactEnvironment>();
+			var config = new Mock<IReactSiteConfiguration>();
 
-			var component = new ReactComponent(environment.Object, "Foo", "container")
+			var component = new ReactComponent(environment.Object, config.Object, "Foo", "container")
 			{
 				Props = new { hello = "World" }
 			};

--- a/src/React/IReactEnvironment.cs
+++ b/src/React/IReactEnvironment.cs
@@ -107,10 +107,5 @@ namespace React
 		/// Gets the JSX Transformer for this environment.
 		/// </summary>
 		IJsxTransformer JsxTransformer { get; }
-
-		/// <summary>
-		/// Gets the global site configuration.
-		/// </summary>
-		IReactSiteConfiguration Configuration { get; }
 	}
 }

--- a/src/React/IReactSiteConfiguration.cs
+++ b/src/React/IReactSiteConfiguration.cs
@@ -45,9 +45,9 @@ namespace React
 		IReactSiteConfiguration SetUseHarmony(bool useHarmony);
 
 		/// <summary>
-		/// Gets the configuration for json serializer.
+		/// Gets or sets the configuration for JSON serializer.
 		/// </summary>
-		JsonSerializerSettings JsonSerializerSettings { get; }
+		JsonSerializerSettings JsonSerializerSettings { get; set; }
 
 		/// <summary>
 		/// Sets the configuration for json serializer.

--- a/src/React/ReactComponent.cs
+++ b/src/React/ReactComponent.cs
@@ -33,6 +33,11 @@ namespace React
 		private readonly IReactEnvironment _environment;
 
 		/// <summary>
+		/// Global site configuration
+		/// </summary>
+		private readonly IReactSiteConfiguration _configuration;
+
+		/// <summary>
 		/// Name of the component
 		/// </summary>
 		private readonly string _componentName;
@@ -51,12 +56,14 @@ namespace React
 		/// Initializes a new instance of the <see cref="ReactComponent"/> class.
 		/// </summary>
 		/// <param name="environment">The environment.</param>
+		/// <param name="configuration">Site-wide configuration.</param>
 		/// <param name="componentName">Name of the component.</param>
 		/// <param name="containerId">The ID of the container DIV for this component</param>
-		public ReactComponent(IReactEnvironment environment, string componentName, string containerId)
+		public ReactComponent(IReactEnvironment environment, IReactSiteConfiguration configuration, string componentName, string containerId)
 		{
 			EnsureComponentNameValid(componentName);
 			_environment = environment;
+			_configuration = configuration;
 			_componentName = componentName;
 			_containerId = containerId;
 		}
@@ -103,7 +110,7 @@ namespace React
 			return string.Format(
 				"React.render({0}, document.getElementById({1}))",
 				GetComponentInitialiser(),
-				JsonConvert.SerializeObject(_containerId, _environment.Configuration.JsonSerializerSettings)
+				JsonConvert.SerializeObject(_containerId, _configuration.JsonSerializerSettings) // SerializeObject accepts null settings
 			);
 		}
 
@@ -133,7 +140,7 @@ namespace React
 		/// <returns>JavaScript for component initialisation</returns>
 		private string GetComponentInitialiser()
 		{
-			var encodedProps = JsonConvert.SerializeObject(Props, _environment.Configuration.JsonSerializerSettings);
+			var encodedProps = JsonConvert.SerializeObject(Props, _configuration.JsonSerializerSettings); // SerializeObject accepts null settings
 			return string.Format(
 				"{0}({1})",
 				_componentName,

--- a/src/React/ReactEnvironment.cs
+++ b/src/React/ReactEnvironment.cs
@@ -268,7 +268,7 @@ namespace React
 			EnsureUserScriptsLoaded();
 			_maxContainerId++;
 			var containerId = string.Format(CONTAINER_ELEMENT_NAME, _maxContainerId);
-			var component = new ReactComponent(this, componentName, containerId)
+			var component = new ReactComponent(this, _config, componentName, containerId)
 			{
 				Props = props
 			};

--- a/src/React/ReactSiteConfiguration.cs
+++ b/src/React/ReactSiteConfiguration.cs
@@ -33,8 +33,6 @@ namespace React
 		/// </summary>
 		private readonly IList<string> _scriptFiles = new List<string>();
 
-		private JsonSerializerSettings _jsonSerializerSettings;
-
 		/// <summary>
 		/// Adds a script to the list of scripts that are executed. This should be called for all
 		/// React components and their dependencies.
@@ -74,11 +72,12 @@ namespace React
 		}
 
 		/// <summary>
-		/// Gets the configuration for json serializer.
+		/// Gets or sets the configuration for JSON serializer.
 		/// </summary>
 		public JsonSerializerSettings JsonSerializerSettings
 		{
-			get { return _jsonSerializerSettings; }
+			get;
+			set;
 		}
 
 		/// <summary>
@@ -91,7 +90,7 @@ namespace React
 		/// </remarks>
 		public IReactSiteConfiguration SetJsonSerializerSettings(JsonSerializerSettings settings)
 		{
-			_jsonSerializerSettings = settings;
+			JsonSerializerSettings = settings;
 			return this;
 		}
 	}


### PR DESCRIPTION
This allows to pass own settings to be used for server-side rendering, for example the same you've got in your ASP.NET configuration:

``` csharp
var settings = GlobalConfiguration.Configuration.Formatters.JsonFormatter.SerializerSettings;

ReactSiteConfiguration.Configuration.SetJsonSerializerSettings(settings);
```
