### PR TITLE
Add renderClientOnly to Html.React to bypass server rendering

### DIFF
--- a/src/React/AssemblyRegistration.cs
+++ b/src/React/AssemblyRegistration.cs
@@ -40,6 +40,7 @@ namespace React
 			container.Register<IJavaScriptEngineFactory, JavaScriptEngineFactory>().AsSingleton();
 
 			container.Register<IReactEnvironment, ReactEnvironment>().AsPerRequestSingleton();
+			container.Register<IReactClientEnvironment, ReactClientEnvironment>().AsPerRequestSingleton();
 
 			// JavaScript engines
 			container.Register(new JavaScriptEngineFactory.Registration

--- a/src/React/IReactClientEnvironment.cs
+++ b/src/React/IReactClientEnvironment.cs
@@ -1,0 +1,25 @@
+namespace React
+{
+	/// <summary>
+	/// Request-specific client only ReactJS.NET environment. This is unique to the individual request and is 
+	/// not shared.
+	/// </summary>
+	public interface IReactClientEnvironment
+	{
+		/// <summary>
+		/// Creates an instance of the specified React JavaScript component.
+		/// </summary>
+		/// <typeparam name="T">Type of the props</typeparam>
+		/// <param name="componentName">Name of the component</param>
+		/// <param name="props">Props to use</param>
+		/// <returns>The component</returns>
+		IReactComponent CreateComponent<T>(string componentName, T props);
+
+		/// <summary>
+		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// attach event handlers to the server-rendered HTML.
+		/// </summary>
+		/// <returns>JavaScript for all components</returns>
+		string GetInitJavaScript();
+	}
+}

--- a/src/React/React.csproj
+++ b/src/React/React.csproj
@@ -85,7 +85,10 @@
     <Compile Include="AssemblyRegistration.cs" />
     <Compile Include="Exceptions\ReactScriptLoadException.cs" />
     <Compile Include="Exceptions\ReactServerRenderingException.cs" />
+    <Compile Include="IReactClientEnvironment.cs" />
     <Compile Include="JavaScriptWithSourceMap.cs" />
+    <Compile Include="ReactClientComponent.cs" />
+    <Compile Include="ReactClientEnvironment.cs" />
     <Compile Include="SourceMap.cs" />
     <Compile Include="SystemEnvironmentUtils.cs" />
     <Compile Include="Exceptions\JsxUnsupportedEngineException.cs" />

--- a/src/React/ReactClientComponent.cs
+++ b/src/React/ReactClientComponent.cs
@@ -1,0 +1,43 @@
+﻿namespace React
+{
+	/// <summary>
+	/// Represents a React JavaScript component.
+	/// </summary>
+	public class ReactClientComponent : ReactComponent
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ReactComponent"/> class.
+		/// </summary>
+		/// <param name="environment">The environment.</param>
+		/// <param name="configuration">Site-wide configuration.</param>
+		/// <param name="componentName">Name of the component.</param>
+		/// <param name="containerId">The ID of the container DIV for this component</param>
+		public ReactClientComponent(IReactEnvironment environment, IReactSiteConfiguration configuration, string componentName, string containerId)
+			: base(environment, configuration, componentName, containerId)
+		{
+		}
+
+		/// <summary>
+		/// We can't verify this without running the scripts so we will assume that it does
+		/// </summary>
+		protected override void EnsureComponentExists()
+		{
+			//Intentionally left empty. We can't verify without running scripts.
+		}
+
+		/// <summary>
+		/// Renders the HTML for this component. This will just render an empty container ready for react 
+		/// to initialize on the client.
+		/// </summary>
+		/// <returns>HTML</returns>
+		public override string RenderHtml()
+		{
+			return string.Format(
+				"<{2} id=\"{0}\">{1}</{2}>",
+				ContainerId,
+				string.Empty,
+				ContainerTag
+				);
+		}
+	}
+}

--- a/src/React/ReactClientEnvironment.cs
+++ b/src/React/ReactClientEnvironment.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace React
+{
+	/// <summary>
+	/// Request-specific client only ReactJS.NET environment. This is unique to the individual request and is 
+	/// not shared.
+	/// </summary>
+	public class ReactClientEnvironment : IReactClientEnvironment
+	{
+		private readonly string CONTAINER_ELEMENT_NAME = "ReactClient{0}";
+		private int _maxContainerId = 0;
+		private readonly List<IReactComponent> _components = new List<IReactComponent>();
+		private readonly IReactEnvironment _reactEnvironment;
+		private readonly IReactSiteConfiguration _config;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ReactClientEnvironment"/> class.
+		/// </summary>
+		/// <param name="reactEnvironment">The React environment</param>
+		/// <param name="config">The site-wide configuration</param>
+		public ReactClientEnvironment(IReactEnvironment reactEnvironment, IReactSiteConfiguration config)
+		{
+			_reactEnvironment = reactEnvironment;
+			_config = config;
+		}
+
+		/// <summary>
+		/// Creates an instance of the specified React JavaScript component.
+		/// </summary>
+		/// <typeparam name="T">Type of the props</typeparam>
+		/// <param name="componentName">Name of the component</param>
+		/// <param name="props">Props to use</param>
+		/// <returns>The component</returns>
+		public virtual IReactComponent CreateComponent<T>(string componentName, T props)
+		{
+			_maxContainerId++;
+			var containerId = string.Format(CONTAINER_ELEMENT_NAME, _maxContainerId);
+			var component = new ReactClientComponent(_reactEnvironment, _config, componentName, containerId)
+			{
+				Props = props
+			};
+			_components.Add(component);
+			return component;
+		}
+
+		/// <summary>
+		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// attach event handlers to the server-rendered HTML.
+		/// </summary>
+		/// <returns>JavaScript for all components</returns>
+		public virtual string GetInitJavaScript()
+		{
+			var fullScript = new StringBuilder();
+			foreach (var component in _components)
+			{
+				fullScript.Append(component.RenderJavaScript());
+				fullScript.AppendLine(";");
+			}
+			return fullScript.ToString();
+		}
+	}
+}


### PR DESCRIPTION
Add this so that you can just render the placeholder for the react component where you want it and then still initialize the data to the component. 

Implementation was a bit hacky, so if you think there is a better way let me know.

You probably should also add a .gitattributes to specify you git settings (line endings etc)