### PR TITLE
JsxTransformer exception now includes whole inner exception, not only message

### DIFF
--- a/src/React/JsxTransformer.cs
+++ b/src/React/JsxTransformer.cs
@@ -140,7 +140,7 @@ namespace React
 						"In file \"{0}\": {1}",
 						filename,
 						ex.Message
-					));
+					), ex);
 				}
 			}
 


### PR DESCRIPTION
JsxTransformer adds the file name to exception message, however it discards the inner exception details, like stack trace. By including the inner exception in the thrown exception object we don't loose any information.

Created again because original PR (https://github.com/reactjs/React.NET/pull/68) was made using wrong base branch.