### PR TITLE
Add HtmlHelperExtension flag to turn off server side rendering

### DIFF
--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -66,7 +66,7 @@ namespace React.AspNet
 		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-		/// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to false</param>
+                /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString React<T>(
 			this IHtmlHelper htmlHelper,
@@ -97,7 +97,7 @@ namespace React.AspNet
 		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-		/// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to false</param>
+                /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString ReactWithInit<T>(
 			this IHtmlHelper htmlHelper,

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -66,13 +66,15 @@ namespace React.AspNet
 		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
+		/// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to false</param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString React<T>(
 			this IHtmlHelper htmlHelper,
 			string componentName,
 			T props,
 			string htmlTag = null,
-			string containerId = null
+			string containerId = null, 
+			bool clientOnly = false
 		)
 		{
 			var reactComponent = Environment.CreateComponent(componentName, props, containerId);
@@ -80,7 +82,7 @@ namespace React.AspNet
 			{
 				reactComponent.ContainerTag = htmlTag;
 			}
-			var result = reactComponent.RenderHtml();
+			var result = reactComponent.RenderHtml(clientOnly);
 			return new HtmlString(result);
 		}
 
@@ -95,13 +97,15 @@ namespace React.AspNet
 		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
+		/// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to false</param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString ReactWithInit<T>(
 			this IHtmlHelper htmlHelper,
 			string componentName,
 			T props,
 			string htmlTag = null,
-			string containerId = null
+			string containerId = null, 
+			bool clientOnly = false
 		)
 		{
 			var reactComponent = Environment.CreateComponent(componentName, props, containerId);
@@ -109,7 +113,7 @@ namespace React.AspNet
 			{
 				reactComponent.ContainerTag = htmlTag;
 			}
-			var html = reactComponent.RenderHtml();
+			var html = reactComponent.RenderHtml(clientOnly);
 			var script = new TagBuilder("script")
 			{
 				InnerHtml = reactComponent.RenderJavaScript()

--- a/src/React.Core/IReactComponent.cs
+++ b/src/React.Core/IReactComponent.cs
@@ -38,8 +38,9 @@ namespace React
 		/// Renders the HTML for this component. This will execute the component server-side and
 		/// return the rendered HTML.
 		/// </summary>
+		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
 		/// <returns>HTML</returns>
-		string RenderHtml();
+		string RenderHtml(bool renderContainerOnly = false);
 
 		/// <summary>
 		/// Renders the JavaScript required to initialise this component client-side. This will 

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -78,15 +78,20 @@ namespace React
 		/// Renders the HTML for this component. This will execute the component server-side and
 		/// return the rendered HTML.
 		/// </summary>
+		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
 		/// <returns>HTML</returns>
-		public virtual string RenderHtml()
+		public virtual string RenderHtml(bool renderContainerOnly = false)
 		{
 			EnsureComponentExists();
 			try
-			{
-				var html = _environment.Execute<string>(
-					string.Format("React.renderToString({0})", GetComponentInitialiser())
+			{ 
+				var html = string.Empty; 
+				if (!renderContainerOnly) 
+				{ 
+					html = _environment.Execute<string>( 
+						string.Format("React.renderToString({0})", GetComponentInitialiser())
 					);
+				}
 				return string.Format(
 					"<{2} id=\"{0}\">{1}</{2}>",
 					ContainerId,

--- a/src/React.Tests/Core/ReactComponentTest.cs
+++ b/src/React.Tests/Core/ReactComponentTest.cs
@@ -76,7 +76,7 @@ namespace React.Tests.Core
 			{
 				Props = new { hello = "World" }
 			};
-			var result = component.RenderHtml(true); //renderContainerOnly = true
+			var result = component.RenderHtml(renderContainerOnly: true);
 
 			Assert.AreEqual(@"<div id=""container""></div>", result);
 			environment.Verify(x => x.Execute(It.IsAny<string>()), Times.Never);

--- a/src/React.Tests/Core/ReactComponentTest.cs
+++ b/src/React.Tests/Core/ReactComponentTest.cs
@@ -64,6 +64,25 @@ namespace React.Tests.Core
 		}
 
 		[Test]
+		public void RenderHtmlShouldNotRenderComponentHTML()
+		{
+			var environment = new Mock<IReactEnvironment>();
+			environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
+			environment.Setup(x => x.Execute<string>(@"React.renderToString(React.createElement(Foo, {""hello"":""World""}))"))
+				.Returns("[HTML]");
+			var config = new Mock<IReactSiteConfiguration>();
+
+			var component = new ReactComponent(environment.Object, config.Object, "Foo", "container")
+			{
+				Props = new { hello = "World" }
+			};
+			var result = component.RenderHtml(true); //renderContainerOnly = true
+
+			Assert.AreEqual(@"<div id=""container""></div>", result);
+			environment.Verify(x => x.Execute(It.IsAny<string>()), Times.Never);
+		}
+
+		[Test]
 		public void RenderHtmlShouldWrapComponentInCustomElement()
 		{
 			var config = new Mock<IReactSiteConfiguration>();

--- a/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace React.Tests.Mvc
 		public void ReactWithInitShouldReturnHtmlAndScript()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml()).Returns("HTML");
+			component.Setup(x => x.RenderHtml(false)).Returns("HTML");
 			component.Setup(x => x.RenderJavaScript()).Returns("JS");
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
@@ -53,6 +53,28 @@ namespace React.Tests.Mvc
 				result.ToString()
 			);
 
+		}
+
+		[Test]
+		public void ReactWithClientOnlyTrueShouldCallRenderHtmlWithTrue()
+		{
+			var component = new Mock<IReactComponent>();
+			component.Setup(x => x.RenderHtml(true)).Returns("HTML");
+			var environment = ConfigureMockEnvironment();
+			environment.Setup(x => x.CreateComponent(
+				"ComponentName",
+				new {},
+				null
+			)).Returns(component.Object);
+
+			var result = HtmlHelperExtensions.React(
+				htmlHelper: null,
+				componentName: "ComponentName", 
+				props: new { }, 
+				htmlTag: "span",
+				clientOnly: true
+			);
+			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true)), Times.Once);
 		}
 	}
 }


### PR DESCRIPTION
I often find myself wanting/needing to disabled server-side rendering during development in order to use the Chrome debugger for troubleshooting javascript syntax issues and various React bugs/errors. My current process is to manually write out the client-side initialization code and commenting out the server-side helper:

```
<div id='temp></div>
React.render(React.createElement(CommentsBox, {"someJson": "blobl"}), document.getElementById("temp"));
```

This PR adds a flag that let's us instruct ReactJS.NET to simply render the client-side initialization code which can easily be turned off (back to server-side + client-side mode) when done debugging/developing.

If you don't think this is appropriate or would prefer it be implemented differently, just let me know. 

jslatts