### PR TITLE
Disable caching of Comments() action

### DIFF
--- a/site/jekyll/getting-started/tutorial.md
+++ b/site/jekyll/getting-started/tutorial.md
@@ -409,9 +409,9 @@ public ActionResult Comments()
 }
 ```
 
-The `OutputCache` attribute is used here to prevent IE from caching the ajax request. IE tries to optimize things by assuming that identical requests will return identical responses. Subsequent calls to the Comments action will simply return the cached response from the first call, the result being that the comment list is never updated in IE as new comments are added. When designing a real world API, cache times of API requests should be considered more carefully. For this tutorial it is easiest to simply disable caching.
+The OutputCache attribute is used here to prevent browsers from caching the response. When designing a real world API, caching of API requests should be considered more carefully. For this tutorial it is easiest to simply disable caching.
 
-Finally we add a corresponding route in `App_Start\RouteConfig.cs` to simplify the request URL a bit:
+Finally we add a corresponding route in `App_Start\RouteConfig.cs`:
 
 ```csharp{12-16}
 using System.Web.Mvc;

--- a/site/jekyll/getting-started/tutorial.md
+++ b/site/jekyll/getting-started/tutorial.md
@@ -402,13 +402,16 @@ namespace ReactDemo.Controllers
 Let's also add a new controller action to return the list of comments:
 
 ```csharp
+[OutputCache(Location = OutputCacheLocation.None)]
 public ActionResult Comments()
 {
 	return Json(_comments, JsonRequestBehavior.AllowGet);
 }
 ```
 
-And a corresponding route in `App_Start\RouteConfig.cs`:
+The `OutputCache` attribute is used here to prevent IE from caching the ajax request. IE tries to optimize things by assuming that identical requests will return identical responses. Subsequent calls to the Comments action will simply return the cached response from the first call, the result being that the comment list is never updated in IE as new comments are added. When designing a real world API, cache times of API requests should be considered more carefully. For this tutorial it is easiest to simply disable caching.
+
+Finally we add a corresponding route in `App_Start\RouteConfig.cs` to simplify the request URL a bit:
 
 ```csharp{12-16}
 using System.Web.Mvc;


### PR DESCRIPTION
Adds an OutputCache attribute the the Comments() action, to prevent IE
from aggressively caching the comments list. Otherwise IE will only show
the comments that were returned in the first request unless you refresh
the entire page.

Fixes #111 