### PR TITLE
Deferred JS Init

### DIFF
--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -121,6 +121,38 @@ namespace React.AspNet
 			return new HtmlString(html + System.Environment.NewLine + script.ToString());
 		}
 
+        /// <summary>
+        /// Renders the specified React component, along with a script block used for
+        /// deferred initialization by <see cref="ReactInitDeferredJavaScript"/>
+        /// </summary>
+        /// <param name="htmlHelper">HTML helper</param>
+        /// <param name="componentName">Name of the component</param>
+        /// <param name="props">Props to initialise the component with</param>
+        /// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
+        /// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
+        /// <typeparam name="T">Type of the props</typeparam>
+        /// <returns></returns>
+        public static IHtmlString ReactWithDeferredInit<T>(
+            this HtmlHelper htmlHelper,
+            string componentName,
+            T props,
+            string htmlTag = null,
+            string containerId = null
+        )
+        {
+            var reactComponent = Environment.CreateComponent(componentName, props, containerId);
+            if (!string.IsNullOrEmpty(htmlTag))
+            {
+                reactComponent.ContainerTag = htmlTag;
+            }
+            var html = reactComponent.RenderHtml();
+            var script = new TagBuilder("script")
+            {
+                InnerHtml = reactComponent.RenderDeferredJavaScript()
+            };
+            return new HtmlString(html + System.Environment.NewLine + script.ToString());
+        }
+        
 		/// <summary>
 		/// Renders the JavaScript required to initialise all components client-side. This will 
 		/// attach event handlers to the server-rendered HTML.
@@ -135,5 +167,20 @@ namespace React.AspNet
 			};
 			return new HtmlString(tag.ToString());
 		}
+
+        /// <summary>
+        /// Renders a Javascript block that initializes all components that have been registered
+        /// to the global react initialization object for delayed initialization.
+        /// </summary>
+        /// <returns>Javascript code block to execute initialization</returns>
+        public static IHtmlString ReactInitDeferredJavaScript(this HtmlHelper htmlHelper)
+        {
+            var script = Environment.GetInitDeferredJavaScript();
+            var tag = new TagBuilder("script")
+            {
+                InnerHtml = script
+            };
+            return new HtmlString(tag.ToString());
+        }
 	}
 }

--- a/src/React.Core/IReactComponent.cs
+++ b/src/React.Core/IReactComponent.cs
@@ -49,5 +49,13 @@ namespace React
 		/// </summary>
 		/// <returns>JavaScript</returns>
 		string RenderJavaScript();
+
+        /// <summary>
+        /// Renders the JavaScript required to allow deferred initialization of the component.
+        /// React is not invoked on this call, but through a separate function that invokes
+        /// all objects that use the deferred render.
+        /// </summary>
+        /// <returns></returns>
+        string RenderDeferredJavaScript();
 	}
 }

--- a/src/React.Core/IReactEnvironment.cs
+++ b/src/React.Core/IReactEnvironment.cs
@@ -92,6 +92,13 @@ namespace React
 		/// <returns>JavaScript for all components</returns>
 		string GetInitJavaScript();
 
+        /// <summary>
+        /// Renders a Javascript block that initializes all components that have been registered
+        /// to the global react initialization object for delayed initialization.
+        /// </summary>
+        /// <returns>Javascript code to execute initialization</returns>
+        string GetInitDeferredJavaScript();
+
 		/// <summary>
 		/// Loads a JSX file. Results of the JSX to JavaScript transformation are cached.
 		/// </summary>

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -121,9 +121,26 @@ namespace React
 			return string.Format(
 				"React.render({0}, document.getElementById({1}))",
 				GetComponentInitialiser(),
-				JsonConvert.SerializeObject(ContainerId, _configuration.JsonSerializerSettings) // SerializeObject accepts null settings
+                GetContainerIdJson()
 			);
 		}
+
+        /// <summary>
+        /// Renders the JavaScript required to allow deferred initialization of the component.
+        /// React is not invoked on this call, but through a separate function that invokes
+        /// all objects that use the deferred render.
+        /// </summary>
+        /// <returns>JavaScript</returns>
+        public virtual string RenderDeferredJavaScript()
+        {
+            return string.Format(
+                @"window.reactComponents = window.reactComponents || [];
+                window.reactComponents.push({{ name: {0}, data: {1}, container: {2} }});",
+                GetComponentNameJson(),
+                GetPropsJson(),
+                GetContainerIdJson()
+            );
+        }
 
 		/// <summary>
 		/// Ensures that this component exists in global scope
@@ -151,11 +168,10 @@ namespace React
 		/// <returns>JavaScript for component initialisation</returns>
 		protected virtual string GetComponentInitialiser()
 		{
-			var encodedProps = JsonConvert.SerializeObject(Props, _configuration.JsonSerializerSettings); // SerializeObject accepts null settings
 			return string.Format(
 				"React.createElement({0}, {1})",
 				ComponentName,
-				encodedProps
+				GetPropsJson()
 			);
 		}
 
@@ -174,5 +190,20 @@ namespace React
 				));
 			}
 		}
+
+        private string GetPropsJson()
+        {
+            return JsonConvert.SerializeObject(Props, _configuration.JsonSerializerSettings);// SerializeObject accepts null settings
+        }
+
+        private string GetContainerIdJson()
+        {
+            return JsonConvert.SerializeObject(ContainerId, _configuration.JsonSerializerSettings);// SerializeObject accepts null settings
+        }
+
+        private string GetComponentNameJson()
+        {
+            return JsonConvert.SerializeObject(ComponentName, _configuration.JsonSerializerSettings);
+        }
 	}
 }

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -303,6 +303,27 @@ namespace React
 			return fullScript.ToString();
 		}
 
+        /// <summary>
+        /// Renders a Javascript block that initializes all components that have been registered
+        /// to the global window object for delayed initialization.
+        /// </summary>
+        /// <returns>Javascript code to execute initialization</returns>
+        public virtual string GetInitDeferredJavaScript()
+        {
+            var sb = new StringBuilder();
+            sb.Append("(function initReactComponents() {");
+            sb.Append("var i, component;");
+            sb.Append("if (!window.reactComponents || !window.reactComponents.length) { return }");
+            sb.Append("for (i = 0; i < window.reactComponents.length; ++i) {");
+            sb.Append("component = window.reactComponents[i];");
+            sb.Append("React.render(React.createElement(window[component.name], component.data), document.getElementById(component.container));");
+            sb.Append("}");
+            sb.Append("delete window.reactComponents;");
+            sb.Append("})();");
+
+            return sb.ToString();
+        }
+
 		/// <summary>
 		/// Loads a JSX file. Results of the JSX to JavaScript transformation are cached.
 		/// </summary>

--- a/src/React.Tests/Core/ReactComponentTest.cs
+++ b/src/React.Tests/Core/ReactComponentTest.cs
@@ -138,5 +138,21 @@ namespace React.Tests.Core
 			}
 			Assert.AreEqual(expected, isValid);
 		}
+
+        [Test]
+        public void RenderDeferredJavaScriptShouldAddComponentToGlobalInitObject()
+        {
+            var environment = new Mock<IReactEnvironment>();
+            var config = new Mock<IReactSiteConfiguration>();
+
+            var component = new ReactComponent(environment.Object, config.Object, "Foo", "container")
+            {
+                Props = new { hello = "World" }
+            };
+            var result = component.RenderDeferredJavaScript();
+            var expected = @"window.reactComponents.push({ name: ""Foo"", data: {""hello"":""World""}, container: ""container"" });";
+
+            Assert.IsTrue(result.EndsWith(expected));
+        }
 	}
 }

--- a/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -76,5 +76,46 @@ namespace React.Tests.Mvc
 			);
 			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true)), Times.Once);
 		}
+
+        [Test]
+        public void ReactInitDeferredJavaScriptShouldReturnHtmlAndInitObject()
+        {
+            var component = new Mock<IReactComponent>();
+            component.Setup(x => x.RenderHtml(false)).Returns("HTML");
+            component.Setup(x => x.RenderDeferredJavaScript()).Returns("JS");
+            var environment = ConfigureMockEnvironment();
+            environment.Setup(x => x.CreateComponent(
+                "ComponentName",
+                new { },
+                null
+            )).Returns(component.Object);
+
+            var result = HtmlHelperExtensions.ReactWithDeferredInit(
+                htmlHelper: null,
+                componentName: "ComponentName",
+                props: new { },
+                htmlTag: "span"
+            );
+            Assert.AreEqual(
+                "HTML" + System.Environment.NewLine + "<script>JS</script>",
+                result.ToString()
+            );
+        }
+
+        [Test]
+        public void ReactInitDeferredJavaScriptReturnsScriptBlockForInit()
+        {
+            var component = new Mock<IReactComponent>();
+            var environment = ConfigureMockEnvironment();
+            environment.Setup(x => x.GetInitDeferredJavaScript()).Returns("JS");
+
+            var result = HtmlHelperExtensions.ReactInitDeferredJavaScript(
+                htmlHelper: null
+            );
+            Assert.AreEqual(
+                "<script>JS</script>",
+                result.ToString()
+            );
+        }
 	}
 }

--- a/src/React.Tests/React.Tests.csproj
+++ b/src/React.Tests/React.Tests.csproj
@@ -126,6 +126,9 @@
   <ItemGroup>
     <Folder Include="Web\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Added functionality to allow React components to be rendered on the server side with the initialization data inline but stored to a global variable so that React is not immediately invoked.  At the end of the page the deferred init JavaScript function needs to be called which will initialize all components on the page.  This functionality is necessary for us to create components across different servers to comprise a page and allow us to load the React.JS script file at the end of the body and not in head.