### PR TITLE
Bypass JSXTransforms load when not needed.

### DIFF
--- a/src/React.Core/IReactSiteConfiguration.cs
+++ b/src/React.Core/IReactSiteConfiguration.cs
@@ -9,7 +9,6 @@
 
 using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace React
 {

--- a/src/React.Core/IReactSiteConfiguration.cs
+++ b/src/React.Core/IReactSiteConfiguration.cs
@@ -9,6 +9,7 @@
 
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace React
 {
@@ -142,5 +143,18 @@ namespace React
 		/// </summary>
 		/// <returns>The configuration, for chaining</returns>
 		IReactSiteConfiguration SetLoadReact(bool loadReact);
+
+		/// <summary>
+		/// Gets or sets whether or not the JSX transforms should be loaded into the JavaScript engine. This setting is only
+		/// applicable when <see cref="LoadReact"></see> is true.
+		/// </summary>
+		bool LoadJsxTransform { get; set; }
+
+		/// <summary>
+		/// Sets whether the JSX Transforms should be loaded into the Javscript engine. This setting is only
+		/// applicable when <see cref="LoadReact"></see> is true.
+		/// </summary>
+		/// <returns>The configuration, for chaining</returns>
+		IReactSiteConfiguration SetLoadJsxTransform(bool loadJsxTransform);
 	}
 }

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -96,17 +96,17 @@ namespace React
 		{
 			var thisAssembly = typeof(ReactEnvironment).Assembly;
 			engine.ExecuteResource("React.Resources.shims.js", thisAssembly);
-		    if (_config.LoadReact)
-		    {
-		        engine.ExecuteResource("React.Resources.react-with-addons.js", thisAssembly);
-		        engine.Execute("React = global.React");
-		        if (_config.Scripts.Any())
-		        {
-		            engine.ExecuteResource("React.Resources.JSXTransformer.js", thisAssembly);
-		        }
-		    }
+			if (_config.LoadReact)
+			{
+				engine.ExecuteResource("React.Resources.react-with-addons.js", thisAssembly);
+				engine.Execute("React = global.React");
+				if (_config.Scripts.Any())
+				{
+					engine.ExecuteResource("React.Resources.JSXTransformer.js", thisAssembly);
+				}
+			}
 
-		    LoadUserScripts(engine);
+			LoadUserScripts(engine);
 			if (!_config.LoadReact)
 			{
 				// We expect to user to have loaded their own versino of React in the scripts that

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -100,7 +100,7 @@ namespace React
 			{
 				engine.ExecuteResource("React.Resources.react-with-addons.js", thisAssembly);
 				engine.Execute("React = global.React");
-				if (_config.Scripts.Any())
+				if (_config.LoadJsxTransform)
 				{
 					engine.ExecuteResource("React.Resources.JSXTransformer.js", thisAssembly);
 				}

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -96,14 +96,17 @@ namespace React
 		{
 			var thisAssembly = typeof(ReactEnvironment).Assembly;
 			engine.ExecuteResource("React.Resources.shims.js", thisAssembly);
-			if (_config.LoadReact)
-			{
-				engine.ExecuteResource("React.Resources.react-with-addons.js", thisAssembly);
-				engine.Execute("React = global.React");
-				engine.ExecuteResource("React.Resources.JSXTransformer.js", thisAssembly);
-			}
+		    if (_config.LoadReact)
+		    {
+		        engine.ExecuteResource("React.Resources.react-with-addons.js", thisAssembly);
+		        engine.Execute("React = global.React");
+		        if (_config.Scripts.Count() > 0)
+		        {
+		            engine.ExecuteResource("React.Resources.JSXTransformer.js", thisAssembly);
+		        }
+		    }
 
-			LoadUserScripts(engine);
+		    LoadUserScripts(engine);
 			if (!_config.LoadReact)
 			{
 				// We expect to user to have loaded their own versino of React in the scripts that

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -100,7 +100,7 @@ namespace React
 		    {
 		        engine.ExecuteResource("React.Resources.react-with-addons.js", thisAssembly);
 		        engine.Execute("React = global.React");
-		        if (_config.Scripts.Count() > 0)
+		        if (_config.Scripts.Any())
 		        {
 		            engine.ExecuteResource("React.Resources.JSXTransformer.js", thisAssembly);
 		        }

--- a/src/React.Core/ReactSiteConfiguration.cs
+++ b/src/React.Core/ReactSiteConfiguration.cs
@@ -37,6 +37,7 @@ namespace React
 			ReuseJavaScriptEngines = true;
 			AllowMsieEngine = true;
 			LoadReact = true;
+			LoadJsxTransform = true;
 			JsonSerializerSettings = new JsonSerializerSettings
 			{
 				StringEscapeHandling = StringEscapeHandling.EscapeHtml
@@ -245,6 +246,23 @@ namespace React
 		public IReactSiteConfiguration SetLoadReact(bool loadReact)
 		{
 			LoadReact = loadReact;
+			return this;
+		}
+
+		/// <summary>
+		/// Gets or sets whether or not the JSX transforms should be loaded into the JavaScript engine. This setting is only
+		/// applicable when <see cref="LoadReact"></see> is true.
+		/// </summary>
+		public bool LoadJsxTransform { get; set; }
+
+		/// <summary>
+		/// Sets whether the JSX Transforms should be loaded into the Javscript engine. This setting is only
+		/// applicable when <see cref="LoadReact"></see> is true.
+		/// </summary>
+		/// <returns>The configuration, for chaining</returns>
+		public IReactSiteConfiguration SetLoadJsxTransform(bool loadJsxTransform)
+		{
+			LoadJsxTransform = loadJsxTransform;
 			return this;
 		}
 	}

--- a/src/React.MSBuild/TransformJsx.cs
+++ b/src/React.MSBuild/TransformJsx.cs
@@ -52,8 +52,7 @@ namespace React.MSBuild
 			config
 				.SetReuseJavaScriptEngines(false)
 				.SetUseHarmony(UseHarmony)
-				.SetStripTypes(StripTypes)
-				.AddScript(string.Empty);
+				.SetStripTypes(StripTypes);
 
 			_environment = React.AssemblyRegistration.Container.Resolve<IReactEnvironment>();
 

--- a/src/React.MSBuild/TransformJsx.cs
+++ b/src/React.MSBuild/TransformJsx.cs
@@ -49,11 +49,11 @@ namespace React.MSBuild
 		{
 			MSBuildHost.EnsureInitialized();
 			var config = React.AssemblyRegistration.Container.Resolve<IReactSiteConfiguration>();
-		    config
-		        .SetReuseJavaScriptEngines(false)
-		        .SetUseHarmony(UseHarmony)
-		        .SetStripTypes(StripTypes)
-		        .AddScript(string.Empty);
+			config
+				.SetReuseJavaScriptEngines(false)
+				.SetUseHarmony(UseHarmony)
+				.SetStripTypes(StripTypes)
+				.AddScript(string.Empty);
 
 			_environment = React.AssemblyRegistration.Container.Resolve<IReactEnvironment>();
 

--- a/src/React.MSBuild/TransformJsx.cs
+++ b/src/React.MSBuild/TransformJsx.cs
@@ -49,10 +49,11 @@ namespace React.MSBuild
 		{
 			MSBuildHost.EnsureInitialized();
 			var config = React.AssemblyRegistration.Container.Resolve<IReactSiteConfiguration>();
-			config
-				.SetReuseJavaScriptEngines(false)
-				.SetUseHarmony(UseHarmony)
-				.SetStripTypes(StripTypes);
+		    config
+		        .SetReuseJavaScriptEngines(false)
+		        .SetUseHarmony(UseHarmony)
+		        .SetStripTypes(StripTypes)
+		        .AddScript(string.Empty);
 
 			_environment = React.AssemblyRegistration.Container.Resolve<IReactEnvironment>();
 


### PR DESCRIPTION
From the recent addition of AddScriptWithoutTransform (which is great BTW, thanks!) it is likely, as is in my case, where I will not be loading any JSX scripts that require transformations.  So if the configuration contains no JSX scripts the JsxTransform script doesn't need to be loaded into the engine.  I may be missing something that this is needed for so please correct me if I am wrong.

Also I am not sure why the spacing looks off on these difs, it's correct in VS.

Thanks!
Joel