### PR TITLE
Render react attributes

### DIFF
--- a/site/jekyll/guides/server-side-rendering.md
+++ b/site/jekyll/guides/server-side-rendering.md
@@ -85,7 +85,7 @@ If thre is no need to have a React application client side and you just want to 
 })
 ```
 
-And the Html markup will look like which is a lot cleaner. In this case there is no need to laod the React script or call the `Html.ReactInitJavaScript()` method.
+And the Html markup will look like the one following which is a lot cleaner. In this case there is no need to laod the React script or call the `Html.ReactInitJavaScript()` method.
 
 ```html
 <div id="react1">

--- a/site/jekyll/guides/server-side-rendering.md
+++ b/site/jekyll/guides/server-side-rendering.md
@@ -72,3 +72,26 @@ meaning your initial render will be super fast.
 
 For a more in-depth example, take a look at the included sample application
 (**React.Samples.Mvc4**).
+
+5 - How not to render the React data attributes
+
+If thre is no need to have a React application client side and you just want to use the server side rendering but without the React specific data attributes call `Html.React` and pass renderReactAttributes parameter as false.
+
+```csharp
+@Html.React("HelloWorld", new
+{
+	name = "Daniel",
+ 	renderReactAttributes: false
+})
+```
+
+And the Html markup will look like which is a lot cleaner. In this case there is no need to laod the React script or call the `Html.ReactInitJavaScript()` method.
+
+```html
+<div id="react1">
+	<div>
+		<span>Hello </span>
+		<span>Daniel</span>
+	</div>
+</div>
+```

--- a/site/jekyll/guides/server-side-rendering.md
+++ b/site/jekyll/guides/server-side-rendering.md
@@ -85,7 +85,7 @@ If thre is no need to have a React application client side and you just want to 
 })
 ```
 
-And the Html markup will look like the one following which is a lot cleaner. In this case there is no need to laod the React script or call the `Html.ReactInitJavaScript()` method.
+And the Html mark up will look like the one following which is a lot cleaner. In this case there is no need to load the React script or call the `Html.ReactInitJavaScript()` method.
 
 ```html
 <div id="react1">

--- a/site/jekyll/guides/server-side-rendering.md
+++ b/site/jekyll/guides/server-side-rendering.md
@@ -73,16 +73,16 @@ meaning your initial render will be super fast.
 For a more in-depth example, take a look at the included sample application
 (**React.Samples.Mvc4**).
 
-5 - How not to render the React data attributes
+5 - Server-side only rendering
 
-If thre is no need to have a React application client side and you just want to use the server side rendering but without the React specific data attributes call `Html.React` and pass renderReactAttributes parameter as false.
+If there is no need to have a React application client side and you just want to use the server side rendering but without the React specific data attributes call `Html.React` and pass serverOnly parameter as true.
 
 ```csharp
 @Html.React("HelloWorld", new
 {
-	name = "Daniel",
- 	renderReactAttributes: false
-})
+	name = "Daniel"
+}
+serverOnly:true)
 ```
 
 And the Html mark up will look like the one following which is a lot cleaner. In this case there is no need to load the React script or call the `Html.ReactInitJavaScript()` method.

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -63,10 +63,11 @@ namespace React.AspNet
 		/// <typeparam name="T">Type of the props</typeparam>
 		/// <param name="htmlHelper">HTML helper</param>
 		/// <param name="componentName">Name of the component</param>
-		/// <param name="props">Props to initialise the component with</param>
+		/// <param name="props">Props to initialize the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-                /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
+        /// <param name="clientOnly">Skip rendering server-side and only output client-side initialization code. Defaults to <c>false</c></param>
+        /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString React<T>(
 			this IHtmlHelper htmlHelper,
@@ -74,7 +75,8 @@ namespace React.AspNet
 			T props,
 			string htmlTag = null,
 			string containerId = null, 
-			bool clientOnly = false
+			bool clientOnly = false,
+            bool renderReactAttributes = true
 		)
 		{
 			var reactComponent = Environment.CreateComponent(componentName, props, containerId);
@@ -82,30 +84,30 @@ namespace React.AspNet
 			{
 				reactComponent.ContainerTag = htmlTag;
 			}
-			var result = reactComponent.RenderHtml(clientOnly);
+			var result = reactComponent.RenderHtml(clientOnly, renderReactAttributes);
 			return new HtmlString(result);
 		}
 
 		/// <summary>
-		/// Renders the specified React component, along with its client-side initialisation code.
+		/// Renders the specified React component, along with its client-side initialization code.
 		/// Normally you would use the <see cref="React{T}"/> method, but <see cref="ReactWithInit{T}"/>
 		/// is useful when rendering self-contained partial views.
 		/// </summary>
 		/// <typeparam name="T">Type of the props</typeparam>
 		/// <param name="htmlHelper">HTML helper</param>
 		/// <param name="componentName">Name of the component</param>
-		/// <param name="props">Props to initialise the component with</param>
+		/// <param name="props">Props to initialize the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-                /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
+        /// <param name="clientOnly">Skip rendering server-side and only output client-side initialization code. Defaults to <c>false</c></param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString ReactWithInit<T>(
 			this IHtmlHelper htmlHelper,
 			string componentName,
 			T props,
 			string htmlTag = null,
-			string containerId = null, 
-			bool clientOnly = false
+			string containerId = null,
+            bool clientOnly = false
 		)
 		{
 			var reactComponent = Environment.CreateComponent(componentName, props, containerId);

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -66,17 +66,17 @@ namespace React.AspNet
 		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-	    /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
-        /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
+		/// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
+		/// <param name="serverOnly">Skip rendering React specific data-attributes during server side rendering. Defaults to <c>false</c></param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString React<T>(
 			this IHtmlHelper htmlHelper,
 			string componentName,
 			T props,
 			string htmlTag = null,
-			string containerId = null, 
+			string containerId = null,
 			bool clientOnly = false,
-            bool renderReactAttributes = true
+			bool serverOnly = false
 		)
 		{
 			var reactComponent = Environment.CreateComponent(componentName, props, containerId);
@@ -84,7 +84,7 @@ namespace React.AspNet
 			{
 				reactComponent.ContainerTag = htmlTag;
 			}
-			var result = reactComponent.RenderHtml(clientOnly, renderReactAttributes);
+			var result = reactComponent.RenderHtml(clientOnly, serverOnly);
 			return new HtmlString(result);
 		}
 
@@ -99,7 +99,7 @@ namespace React.AspNet
 		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-        /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
+		/// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString ReactWithInit<T>(
 			this IHtmlHelper htmlHelper,
@@ -124,7 +124,7 @@ namespace React.AspNet
 		}
 
 		/// <summary>
-		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// Renders the JavaScript required to initialise all components client-side. This will
 		/// attach event handlers to the server-rendered HTML.
 		/// </summary>
 		/// <returns>JavaScript for all components</returns>

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -63,10 +63,10 @@ namespace React.AspNet
 		/// <typeparam name="T">Type of the props</typeparam>
 		/// <param name="htmlHelper">HTML helper</param>
 		/// <param name="componentName">Name of the component</param>
-		/// <param name="props">Props to initialize the component with</param>
+		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-        /// <param name="clientOnly">Skip rendering server-side and only output client-side initialization code. Defaults to <c>false</c></param>
+	    /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
         /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString React<T>(
@@ -89,17 +89,17 @@ namespace React.AspNet
 		}
 
 		/// <summary>
-		/// Renders the specified React component, along with its client-side initialization code.
+		/// Renders the specified React component, along with its client-side initialisation code.
 		/// Normally you would use the <see cref="React{T}"/> method, but <see cref="ReactWithInit{T}"/>
 		/// is useful when rendering self-contained partial views.
 		/// </summary>
 		/// <typeparam name="T">Type of the props</typeparam>
 		/// <param name="htmlHelper">HTML helper</param>
 		/// <param name="componentName">Name of the component</param>
-		/// <param name="props">Props to initialize the component with</param>
+		/// <param name="props">Props to initialise the component with</param>
 		/// <param name="htmlTag">HTML tag to wrap the component in. Defaults to &lt;div&gt;</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
-        /// <param name="clientOnly">Skip rendering server-side and only output client-side initialization code. Defaults to <c>false</c></param>
+        /// <param name="clientOnly">Skip rendering server-side and only output client-side initialisation code. Defaults to <c>false</c></param>
 		/// <returns>The component's HTML</returns>
 		public static IHtmlString ReactWithInit<T>(
 			this IHtmlHelper htmlHelper,

--- a/src/React.Core/IReactComponent.cs
+++ b/src/React.Core/IReactComponent.cs
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -39,13 +39,13 @@ namespace React
 		/// return the rendered HTML.
 		/// </summary>
 		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
-        /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
+		/// <param name="renderServerOnly">Only renders the common HTML mark up and not any React specific data attributes. Used for server-side only rendering.</param>
 		/// <returns>HTML</returns>
-        string RenderHtml(bool renderContainerOnly = false, bool renderReactAttributes = true);
+		string RenderHtml(bool renderContainerOnly = false, bool renderServerOnly = false);
 
 		/// <summary>
-		/// Renders the JavaScript required to initialise this component client-side. This will 
-		/// initialise the React component, which includes attach event handlers to the 
+		/// Renders the JavaScript required to initialise this component client-side. This will
+		/// initialise the React component, which includes attach event handlers to the
 		/// server-rendered HTML.
 		/// </summary>
 		/// <returns>JavaScript</returns>

--- a/src/React.Core/IReactComponent.cs
+++ b/src/React.Core/IReactComponent.cs
@@ -39,8 +39,9 @@ namespace React
 		/// return the rendered HTML.
 		/// </summary>
 		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
+        /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
 		/// <returns>HTML</returns>
-		string RenderHtml(bool renderContainerOnly = false);
+        string RenderHtml(bool renderContainerOnly = false, bool renderReactAttributes = true);
 
 		/// <summary>
 		/// Renders the JavaScript required to initialise this component client-side. This will 

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -79,20 +79,20 @@ namespace React
 		/// return the rendered HTML.
 		/// </summary>
 		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
-        /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
+		/// <param name="renderServerOnly">Only renders the common HTML mark up and not any React specific data attributes. Used for server-side only rendering.</param>
 		/// <returns>HTML</returns>
-        public virtual string RenderHtml(bool renderContainerOnly = false, bool renderReactAttributes = true)
+		public virtual string RenderHtml(bool renderContainerOnly = false, bool renderServerOnly = false)
 		{
 			EnsureComponentExists();
 			try
-			{ 
-				var html = string.Empty; 
-				if (!renderContainerOnly) 
+			{
+				var html = string.Empty;
+				if (!renderContainerOnly)
 				{
-                    var reactRenderCommand = renderReactAttributes
-                        ? string.Format("React.renderToString({0})", GetComponentInitialiser())
-                        : string.Format("React.renderToStaticMarkup({0})", GetComponentInitialiser());
-                    html = _environment.Execute<string>(reactRenderCommand);
+					var reactRenderCommand = renderServerOnly
+						? string.Format("React.renderToStaticMarkup({0})", GetComponentInitialiser())
+						: string.Format("React.renderToString({0})", GetComponentInitialiser());
+					html = _environment.Execute<string>(reactRenderCommand);
 				}
 				return string.Format(
 					"<{2} id=\"{0}\">{1}</{2}>",
@@ -113,8 +113,8 @@ namespace React
 		}
 
 		/// <summary>
-		/// Renders the JavaScript required to initialise this component client-side. This will 
-		/// initialise the React component, which includes attach event handlers to the 
+		/// Renders the JavaScript required to initialise this component client-side. This will
+		/// initialise the React component, which includes attach event handlers to the
 		/// server-rendered HTML.
 		/// </summary>
 		/// <returns>JavaScript</returns>

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -79,18 +79,20 @@ namespace React
 		/// return the rendered HTML.
 		/// </summary>
 		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
+        /// <param name="renderReactAttributes">Indicates if the React data-attributes should be rendered during server side rendering</param>
 		/// <returns>HTML</returns>
-		public virtual string RenderHtml(bool renderContainerOnly = false)
+        public virtual string RenderHtml(bool renderContainerOnly = false, bool renderReactAttributes = true)
 		{
 			EnsureComponentExists();
 			try
 			{ 
 				var html = string.Empty; 
 				if (!renderContainerOnly) 
-				{ 
-					html = _environment.Execute<string>( 
-						string.Format("React.renderToString({0})", GetComponentInitialiser())
-					);
+				{
+                    var reactRenderCommand = renderReactAttributes
+                        ? string.Format("React.renderToString({0})", GetComponentInitialiser())
+                        : string.Format("React.renderToStaticMarkup({0})", GetComponentInitialiser());
+                    html = _environment.Execute<string>(reactRenderCommand);
 				}
 				return string.Format(
 					"<{2} id=\"{0}\">{1}</{2}>",

--- a/src/React.Tests/Core/ReactComponentTest.cs
+++ b/src/React.Tests/Core/ReactComponentTest.cs
@@ -64,7 +64,7 @@ namespace React.Tests.Core
 		}
 
 		[Test]
-		public void RenderHtmlShouldNotRenderComponentHTML()
+		public void RenderHtmlShouldNotRenderComponentHtml()
 		{
 			var environment = new Mock<IReactEnvironment>();
 			environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
@@ -81,6 +81,22 @@ namespace React.Tests.Core
 			Assert.AreEqual(@"<div id=""container""></div>", result);
 			environment.Verify(x => x.Execute(It.IsAny<string>()), Times.Never);
 		}
+
+        [Test]
+        public void RenderHtmlShouldNotRenderReactAttributes() 
+        {
+            var environment = new Mock<IReactEnvironment>();
+            environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
+            var config = new Mock<IReactSiteConfiguration>();
+
+            var component = new ReactComponent(environment.Object, config.Object, "Foo", "container") 
+            {
+                Props = new { hello = "World" }
+            };
+            component.RenderHtml(renderReactAttributes: false);
+
+            environment.Verify(x => x.Execute<string>(@"React.renderToStaticMarkup(React.createElement(Foo, {""hello"":""World""}))"));
+        }
 
 		[Test]
 		public void RenderHtmlShouldWrapComponentInCustomElement()

--- a/src/React.Tests/Core/ReactComponentTest.cs
+++ b/src/React.Tests/Core/ReactComponentTest.cs
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -82,21 +82,21 @@ namespace React.Tests.Core
 			environment.Verify(x => x.Execute(It.IsAny<string>()), Times.Never);
 		}
 
-        [Test]
-        public void RenderHtmlShouldNotRenderReactAttributes() 
-        {
-            var environment = new Mock<IReactEnvironment>();
-            environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
-            var config = new Mock<IReactSiteConfiguration>();
+		[Test]
+		public void RenderHtmlShouldNotRenderClientSideAttributes()
+		{
+			var environment = new Mock<IReactEnvironment>();
+			environment.Setup(x => x.Execute<bool>("typeof Foo !== 'undefined'")).Returns(true);
+			var config = new Mock<IReactSiteConfiguration>();
 
-            var component = new ReactComponent(environment.Object, config.Object, "Foo", "container") 
-            {
-                Props = new { hello = "World" }
-            };
-            component.RenderHtml(renderReactAttributes: false);
+			var component = new ReactComponent(environment.Object, config.Object, "Foo", "container")
+			{
+				Props = new { hello = "World" }
+			};
+			component.RenderHtml(renderServerOnly: true);
 
-            environment.Verify(x => x.Execute<string>(@"React.renderToStaticMarkup(React.createElement(Foo, {""hello"":""World""}))"));
-        }
+			environment.Verify(x => x.Execute<string>(@"React.renderToStaticMarkup(React.createElement(Foo, {""hello"":""World""}))"));
+		}
 
 		[Test]
 		public void RenderHtmlShouldWrapComponentInCustomElement()

--- a/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -19,7 +19,7 @@ namespace React.Tests.Mvc
 	{
 		/// <summary>
 		/// Creates a mock <see cref="IReactEnvironment"/> and registers it with the IoC container
-		/// This is only required because <see cref="HtmlHelperExtensions"/> can not be 
+		/// This is only required because <see cref="HtmlHelperExtensions"/> can not be
 		/// injected :(
 		/// </summary>
 		private Mock<IReactEnvironment> ConfigureMockEnvironment()
@@ -33,7 +33,7 @@ namespace React.Tests.Mvc
 		public void ReactWithInitShouldReturnHtmlAndScript()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(false, true)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(false, false)).Returns("HTML");
 			component.Setup(x => x.RenderJavaScript()).Returns("JS");
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
@@ -44,12 +44,12 @@ namespace React.Tests.Mvc
 
 			var result = HtmlHelperExtensions.ReactWithInit(
 				htmlHelper: null,
-				componentName: "ComponentName", 
-				props: new { }, 
+				componentName: "ComponentName",
+				props: new { },
 				htmlTag: "span"
 			);
 			Assert.AreEqual(
-				"HTML" + System.Environment.NewLine + "<script>JS</script>", 
+				"HTML" + System.Environment.NewLine + "<script>JS</script>",
 				result.ToString()
 			);
 
@@ -69,35 +69,35 @@ namespace React.Tests.Mvc
 
 			var result = HtmlHelperExtensions.React(
 				htmlHelper: null,
-				componentName: "ComponentName", 
-				props: new { }, 
+				componentName: "ComponentName",
+				props: new { },
 				htmlTag: "span",
 				clientOnly: true,
-                renderReactAttributes: true
+				serverOnly: true
 			);
-		    component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == true)), Times.Once);
+			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == true)), Times.Once);
 		}
 
-        [Test]
-        public void ReactWithRenderReactAttributesfalseShouldCallRenderHtmlWithfalse() {
-            var component = new Mock<IReactComponent>();
-            component.Setup(x => x.RenderHtml(true, false)).Returns("HTML");
-            var environment = ConfigureMockEnvironment();
-            environment.Setup(x => x.CreateComponent(
-                "ComponentName",
-                new { },
-                null
-            )).Returns(component.Object);
+		[Test]
+		public void ReactWithServerOnlyTrueShouldCallRenderHtmlWithTrue() {
+			var component = new Mock<IReactComponent>();
+			component.Setup(x => x.RenderHtml(true, true)).Returns("HTML");
+			var environment = ConfigureMockEnvironment();
+			environment.Setup(x => x.CreateComponent(
+				"ComponentName",
+				new { },
+				null
+			)).Returns(component.Object);
 
-            var result = HtmlHelperExtensions.React(
-                htmlHelper: null,
-                componentName: "ComponentName",
-                props: new { },
-                htmlTag: "span",
-                clientOnly: true,
-                renderReactAttributes: false
-            );
-            component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == false)), Times.Once);
-        }
+			var result = HtmlHelperExtensions.React(
+				htmlHelper: null,
+				componentName: "ComponentName",
+				props: new { },
+				htmlTag: "span",
+				clientOnly: true,
+				serverOnly: true
+			);
+			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == true)), Times.Once);
+		}
 	}
 }

--- a/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -59,7 +59,7 @@ namespace React.Tests.Mvc
 		public void ReactWithClientOnlyTrueShouldCallRenderHtmlWithTrue()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(true, false)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(true, true)).Returns("HTML");
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
@@ -73,9 +73,31 @@ namespace React.Tests.Mvc
 				props: new { }, 
 				htmlTag: "span",
 				clientOnly: true,
-                renderReactAttributes: false
+                renderReactAttributes: true
 			);
-		    component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == false)), Times.Once);
+		    component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == true)), Times.Once);
 		}
+
+        [Test]
+        public void ReactWithRenderReactAttributesfalseShouldCallRenderHtmlWithfalse() {
+            var component = new Mock<IReactComponent>();
+            component.Setup(x => x.RenderHtml(true, false)).Returns("HTML");
+            var environment = ConfigureMockEnvironment();
+            environment.Setup(x => x.CreateComponent(
+                "ComponentName",
+                new { },
+                null
+            )).Returns(component.Object);
+
+            var result = HtmlHelperExtensions.React(
+                htmlHelper: null,
+                componentName: "ComponentName",
+                props: new { },
+                htmlTag: "span",
+                clientOnly: true,
+                renderReactAttributes: false
+            );
+            component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == false)), Times.Once);
+        }
 	}
 }

--- a/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace React.Tests.Mvc
 		public void ReactWithInitShouldReturnHtmlAndScript()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(false)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(false, true)).Returns("HTML");
 			component.Setup(x => x.RenderJavaScript()).Returns("JS");
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
@@ -59,7 +59,7 @@ namespace React.Tests.Mvc
 		public void ReactWithClientOnlyTrueShouldCallRenderHtmlWithTrue()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(true)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(true, false)).Returns("HTML");
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
@@ -72,9 +72,10 @@ namespace React.Tests.Mvc
 				componentName: "ComponentName", 
 				props: new { }, 
 				htmlTag: "span",
-				clientOnly: true
+				clientOnly: true,
+                renderReactAttributes: false
 			);
-			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true)), Times.Once);
+		    component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == false)), Times.Once);
 		}
 	}
 }


### PR DESCRIPTION
Added an optional parameter to the `Render` method of `IReactCompoment` interface with default value to true. This won't change the behavior of the existing applications. On the other hand gives the flexibility to not render the React data attributes during server side rendering if there is a need. Internally has implemented by calling `React.renderToStaticMarkup` method instead the default` React.renderToString`. I changed the corresponding method in `HtmlHelperExtensions` class. At last I didn't figure out how to make sure that my code lints. Is there a tool or something like this we have to execute? #127 