### PR TITLE
Prevent ReactComponent to serialize Props twice on one http request.

### DIFF
--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -38,6 +38,11 @@ namespace React
 		protected readonly IReactSiteConfiguration _configuration;
 
 		/// <summary>
+		/// Serialized <see cref="Props" />
+		/// </summary>
+		protected string _serializedProps;
+
+		/// <summary>
 		/// Gets or sets the name of the component
 		/// </summary>
 		public string ComponentName { get; set; }
@@ -165,11 +170,15 @@ namespace React
 		/// <returns>JavaScript for component initialisation</returns>
 		protected virtual string GetComponentInitialiser()
 		{
-			var encodedProps = JsonConvert.SerializeObject(Props, _configuration.JsonSerializerSettings); // SerializeObject accepts null settings
+			if (_serializedProps == null)
+			{
+				_serializedProps = JsonConvert.SerializeObject(Props, _configuration.JsonSerializerSettings); // SerializeObject accepts null settings
+			}
+
 			return string.Format(
 				"React.createElement({0}, {1})",
 				ComponentName,
-				encodedProps
+				_serializedProps
 			);
 		}
 


### PR DESCRIPTION
Small performance improvement to prevent ReactComponent to serialize `Props` twice on one http request:
* first time on `@Html.React` call
* second time on `@Html.ReactInitJavaScript` call
