### PR TITLE
Allow Javascript engines to be bypassed entirely.

### DIFF
--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -81,7 +81,7 @@ namespace React.AspNet
 			string containerClass = null
 		)
 		{
-			var reactComponent = Environment.CreateComponent(componentName, props, containerId);
+			var reactComponent = Environment.CreateComponent(componentName, props, containerId, clientOnly);
 			if (!string.IsNullOrEmpty(htmlTag))
 			{
 				reactComponent.ContainerTag = htmlTag;
@@ -118,7 +118,7 @@ namespace React.AspNet
 			string containerClass = null
 		)
 		{
-			var reactComponent = Environment.CreateComponent(componentName, props, containerId);
+			var reactComponent = Environment.CreateComponent(componentName, props, containerId, clientOnly);
 			if (!string.IsNullOrEmpty(htmlTag))
 			{
 				reactComponent.ContainerTag = htmlTag;
@@ -146,9 +146,9 @@ namespace React.AspNet
 		/// attach event handlers to the server-rendered HTML.
 		/// </summary>
 		/// <returns>JavaScript for all components</returns>
-		public static IHtmlString ReactInitJavaScript(this IHtmlHelper htmlHelper)
+		public static IHtmlString ReactInitJavaScript(this IHtmlHelper htmlHelper, bool clientOnly = false)
 		{
-			var script = Environment.GetInitJavaScript();
+			var script = Environment.GetInitJavaScript(clientOnly);
 #if LEGACYASPNET
 			var tag = new TagBuilder("script")
 			{

--- a/src/React.Core/IReactEnvironment.cs
+++ b/src/React.Core/IReactEnvironment.cs
@@ -80,15 +80,17 @@ namespace React
 		/// <param name="componentName">Name of the component</param>
 		/// <param name="props">Props to use</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
 		/// <returns>The component</returns>
-		IReactComponent CreateComponent<T>(string componentName, T props, string containerId = null);
+		IReactComponent CreateComponent<T>(string componentName, T props, string containerId = null, bool clientOnly = false);
 
 		/// <summary>
 		/// Renders the JavaScript required to initialise all components client-side. This will 
 		/// attach event handlers to the server-rendered HTML.
 		/// </summary>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
 		/// <returns>JavaScript for all components</returns>
-		string GetInitJavaScript();
+		string GetInitJavaScript(bool clientOnly = false);
 
 		/// <summary>
 		/// Gets the JSX Transformer for this environment.

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -89,7 +89,11 @@ namespace React
 		/// <returns>HTML</returns>
 		public virtual string RenderHtml(bool renderContainerOnly = false, bool renderServerOnly = false)
 		{
-			EnsureComponentExists();
+			if (!renderContainerOnly)
+			{
+				EnsureComponentExists();
+			}
+
 			try
 			{
 				var html = string.Empty;

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -256,10 +256,15 @@ namespace React
 		/// <param name="componentName">Name of the component</param>
 		/// <param name="props">Props to use</param>
 		/// <param name="containerId">ID to use for the container HTML tag. Defaults to an auto-generated ID</param>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
 		/// <returns>The component</returns>
-		public virtual IReactComponent CreateComponent<T>(string componentName, T props, string containerId = null)
+		public virtual IReactComponent CreateComponent<T>(string componentName, T props, string containerId = null, bool clientOnly = false)
 		{
-			EnsureUserScriptsLoaded();
+			if (!clientOnly)
+			{
+				EnsureUserScriptsLoaded();
+			}
+
 			var component = new ReactComponent(this, _config, componentName, containerId)
 			{
 				Props = props
@@ -272,14 +277,18 @@ namespace React
 		/// Renders the JavaScript required to initialise all components client-side. This will 
 		/// attach event handlers to the server-rendered HTML.
 		/// </summary>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
 		/// <returns>JavaScript for all components</returns>
-		public virtual string GetInitJavaScript()
+		public virtual string GetInitJavaScript(bool clientOnly = false)
 		{
 			var fullScript = new StringBuilder();
 			
 			// Propagate any server-side console.log calls to corresponding client-side calls.
-			var consoleCalls = Execute<string>("console.getCalls()");
-			fullScript.Append(consoleCalls);
+			if (!clientOnly)
+			{
+				var consoleCalls = Execute<string>("console.getCalls()");
+				fullScript.Append(consoleCalls);
+			}
 			
 			foreach (var component in _components)
 			{

--- a/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/src/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -39,7 +39,8 @@ namespace React.Tests.Mvc
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
 				new {},
-				null
+				null,
+				false
 			)).Returns(component.Object);
 
 			var result = HtmlHelperExtensions.ReactWithInit(
@@ -64,7 +65,8 @@ namespace React.Tests.Mvc
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
 				new {},
-				null
+				null,
+				true
 			)).Returns(component.Object);
 
 			var result = HtmlHelperExtensions.React(
@@ -86,7 +88,8 @@ namespace React.Tests.Mvc
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
 				new { },
-				null
+				null,
+				true
 			)).Returns(component.Object);
 
 			var result = HtmlHelperExtensions.React(


### PR DESCRIPTION
If no server-side rendering will occur on a page, for instance if
component render is called with clientOnly: true, it is
pointless to initialize a Javascript engine on the server. This allows the
consumer to easily disable all server side Javascript if the server is
under heavy load.