### PR TITLE
Fixing duplicate dependencies

### DIFF
--- a/src/React.AspNet/project.json
+++ b/src/React.AspNet/project.json
@@ -26,16 +26,11 @@
     }
   },
   "dependencies": {
-    "JsPool": "0.4.1",
     "Microsoft.AspNetCore.Mvc.Core": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
     "Microsoft.Extensions.FileProviders.Physical": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.0-rc2-final",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-final",
-    "JavaScriptEngineSwitcher.Core": "1.5.0",
-    "JavaScriptEngineSwitcher.Msie": "1.5.0",
-    "JavaScriptEngineSwitcher.V8": "1.5.2",
-    "MsieJavaScriptEngine": "1.7.0",
     "React.Core": {
       "target": "project"
     }

--- a/src/React.Core/packages.config
+++ b/src/React.Core/packages.config
@@ -3,7 +3,7 @@
   <package id="JavaScriptEngineSwitcher.Core" version="1.5.0" targetFramework="net40" />
   <package id="JavaScriptEngineSwitcher.Msie" version="1.5.0" targetFramework="net40" />
   <package id="JavaScriptEngineSwitcher.V8" version="1.5.2" targetFramework="net40" />
-  <package id="JSPool" version="0.4.1" targetFramework="net40" />
+  <package id="JSPool" version="0.4.1" targetFramework="net40-client" />
   <package id="MsieJavaScriptEngine" version="1.7.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" />
 </packages>

--- a/src/React.Sample.Mvc6/project.json
+++ b/src/React.Sample.Mvc6/project.json
@@ -2,7 +2,6 @@
   "version": "2.3.0-*",
 
   "dependencies": {
-    "JsPool": "0.4.1",
     "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
@@ -14,8 +13,6 @@
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0-rc2-final",
-    "JavaScriptEngineSwitcher.Msie": "1.5.0",
-    "JavaScriptEngineSwitcher.V8": "1.5.2",
     "React.Core": {
       "target": "project"
     },

--- a/src/wrap/React.Core/project.json
+++ b/src/wrap/React.Core/project.json
@@ -8,6 +8,7 @@
         "pdb": "../../React.Core/obj/{configuration}/React.Core.pdb"
       },
       "dependencies": {
+        "JsPool": "0.4.1",
         "JavaScriptEngineSwitcher.Core": "1.5.0",
         "JavaScriptEngineSwitcher.Msie": "1.5.0",
         "JavaScriptEngineSwitcher.V8": "1.5.2",


### PR DESCRIPTION
Right now there is a problem with nuget, when resolving xproj with dependencies that contents other dependencies that contents dependencies you have also as dependencies for the project itself, as it is having problems with finding the dlls you already downloaded.

The way I found to fix this was to delete the base dependencies that are going to be needed anyway for another dependency.

Fixes issue #269