### PR TITLE
Updating .NET Core libraries from 1.0 RC2 to 1.0 RTM

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -45,7 +45,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 		<!-- NuGet packages for ASP.NET Core projects -->
 		<Exec
 			WorkingDirectory="$(MSBuildProjectDirectory)"
-			Command="dotnet restore --quiet src\React.AspNet src\React.Sample.Mvc6"
+			Command="dotnet restore src\React.AspNet src\React.Sample.Mvc6"
 		/>
 		<!-- npm packages -->
 		<Exec

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -17,6 +17,7 @@ using IHtmlHelper = System.Web.Mvc.HtmlHelper;
 #else
 using Microsoft.AspNetCore.Mvc.Rendering;
 using IHtmlString = Microsoft.AspNetCore.Html.IHtmlContent;
+using Microsoft.AspNetCore.Html;
 #endif
 
 #if LEGACYASPNET

--- a/src/React.AspNet/project.json
+++ b/src/React.AspNet/project.json
@@ -26,11 +26,11 @@
     }
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Mvc.Core": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
-    "Microsoft.Extensions.FileProviders.Physical": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.0-rc2-final",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+    "Microsoft.Extensions.FileProviders.Physical": "1.0.0",
+    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "React.Core": {
       "target": "project"
     }

--- a/src/React.Sample.Mvc6/project.json
+++ b/src/React.Sample.Mvc6/project.json
@@ -2,17 +2,17 @@
   "version": "2.4.0-*",
 
   "dependencies": {
-    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
-    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.NETCore.Platforms": "1.0.1",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
     "React.Core": {
       "target": "project"
     },
@@ -23,7 +23,7 @@
 
   "tools": {
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-*",
+      "version": "1.0.0-preview2-final",
       "imports": "portable-net45+win8+dnxcore50"
     }
   },

--- a/src/global.json
+++ b/src/global.json
@@ -3,7 +3,7 @@
     "wrap"
   ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   },
   "projects": [
     "wrap"


### PR DESCRIPTION
Changes from RC2 to RTM are minimal, so there shouldn't be that many problems