### PR TITLE
Use file hash to check for file changes before transpiling (#299)

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+
+[*.json]
+indent_size = 2
+indent_style = space

--- a/src/React.Core/Babel.cs
+++ b/src/React.Core/Babel.cs
@@ -351,35 +351,36 @@ namespace React
 		{
 			var outputPath = GetOutputPath(filename);
 			var contents = _fileSystem.ReadAsString(filename);
-            if (MustTranspileFile(contents, outputPath))
-            {
-                var result = TransformWithHeader(filename, contents, null);
+			if (CacheIsValid(contents, outputPath))
+				return outputPath;
+			
+			var result = TransformWithHeader(filename, contents, null);
 
-                var sourceMapPath = GetSourceMapOutputPath(filename);
-                _fileSystem.WriteAsString(outputPath, result.Code);
-                _fileSystem.WriteAsString(sourceMapPath, result.SourceMap == null ? string.Empty : result.SourceMap.ToJson());                
-            }
-		    return outputPath;
+			var sourceMapPath = GetSourceMapOutputPath(filename);
+			_fileSystem.WriteAsString(outputPath, result.Code);
+			_fileSystem.WriteAsString(sourceMapPath, result.SourceMap == null ? string.Empty : result.SourceMap.ToJson());                
+			
+			return outputPath;
 		}
 
-        /// <summary>
-        /// Checks whether an input file (given as inputFileContents) should be transpiled
-        /// by calculating the hash and comparing it to the hash value stored
-        /// in the file given by outputPath. If the outputPath file does not
-        /// exist the input file should always be transpiled.
-        /// </summary>
-        /// <param name="inputFileContents">The contents of the input file.</param>
-        /// <param name="outputPath">The output path of the (possibly previously) generated file.</param>
-        /// <returns>Returns true if the file should be transpiled, false otherwise.</returns>
-	    public virtual bool MustTranspileFile(string inputFileContents, string outputPath)
-	    {
-	        if (!File.Exists(outputPath))
-	            return true;
+		/// <summary>
+		/// Checks whether an input file (given as inputFileContents) should be transpiled
+		/// by calculating the hash and comparing it to the hash value stored
+		/// in the file given by outputPath. If the outputPath file does not
+		/// exist the input file should always be transpiled.
+		/// </summary>
+		/// <param name="inputFileContents">The contents of the input file.</param>
+		/// <param name="outputPath">The output path of the (possibly previously) generated file.</param>
+		/// <returns>Returns true if the file should be transpiled, false otherwise.</returns>
+		public virtual bool CacheIsValid(string inputFileContents, string outputPath)
+		{            
+			if (!_fileSystem.FileExists(outputPath))
+				return false;
 
-	        var hashForInputFile = _fileCacheHash.CalculateHash(inputFileContents);
-	        var existingOutputContents = _fileSystem.ReadAsString(outputPath);
-	        var fileHasNotChanged = _fileCacheHash.ValidateHash(existingOutputContents, hashForInputFile);
-	        return !fileHasNotChanged;
-	    }
+			var hashForInputFile = _fileCacheHash.CalculateHash(inputFileContents);
+			var existingOutputContents = _fileSystem.ReadAsString(outputPath);
+			var fileHasNotChanged = _fileCacheHash.ValidateHash(existingOutputContents, hashForInputFile);
+			return fileHasNotChanged;
+		}
 	}
 }

--- a/src/React.Core/Babel.cs
+++ b/src/React.Core/Babel.cs
@@ -371,7 +371,7 @@ namespace React
 		/// </summary>
 		/// <param name="inputFileContents">The contents of the input file.</param>
 		/// <param name="outputPath">The output path of the (possibly previously) generated file.</param>
-		/// <returns>Returns true if the file should be transpiled, false otherwise.</returns>
+		/// <returns>Returns false if the file should be transpiled, true otherwise.</returns>
 		public virtual bool CacheIsValid(string inputFileContents, string outputPath)
 		{            
 			if (!_fileSystem.FileExists(outputPath))

--- a/src/React.Core/Babel.cs
+++ b/src/React.Core/Babel.cs
@@ -350,12 +350,36 @@ namespace React
 		)
 		{
 			var outputPath = GetOutputPath(filename);
-			var sourceMapPath = GetSourceMapOutputPath(filename);
 			var contents = _fileSystem.ReadAsString(filename);
-			var result = TransformWithHeader(filename, contents, null);
-			_fileSystem.WriteAsString(outputPath, result.Code);
-			_fileSystem.WriteAsString(sourceMapPath, result.SourceMap == null ? string.Empty : result.SourceMap.ToJson());
-			return outputPath;
+            if (MustTranspileFile(contents, outputPath))
+            {
+                var result = TransformWithHeader(filename, contents, null);
+
+                var sourceMapPath = GetSourceMapOutputPath(filename);
+                _fileSystem.WriteAsString(outputPath, result.Code);
+                _fileSystem.WriteAsString(sourceMapPath, result.SourceMap == null ? string.Empty : result.SourceMap.ToJson());                
+            }
+		    return outputPath;
 		}
+
+        /// <summary>
+        /// Checks whether an input file (given as inputFileContents) should be transpiled
+        /// by calculating the hash and comparing it to the hash value stored
+        /// in the file given by outputPath. If the outputPath file does not
+        /// exist the input file should always be transpiled.
+        /// </summary>
+        /// <param name="inputFileContents">The contents of the input file.</param>
+        /// <param name="outputPath">The output path of the (possibly previously) generated file.</param>
+        /// <returns>Returns true if the file should be transpiled, false otherwise.</returns>
+	    public virtual bool MustTranspileFile(string inputFileContents, string outputPath)
+	    {
+	        if (!File.Exists(outputPath))
+	            return true;
+
+	        var hashForInputFile = _fileCacheHash.CalculateHash(inputFileContents);
+	        var existingOutputContents = _fileSystem.ReadAsString(outputPath);
+	        var fileHasNotChanged = _fileCacheHash.ValidateHash(existingOutputContents, hashForInputFile);
+	        return !fileHasNotChanged;
+	    }
 	}
 }

--- a/src/React.Tests/Core/BabelTransformerTests.cs
+++ b/src/React.Tests/Core/BabelTransformerTests.cs
@@ -32,6 +32,10 @@ namespace React.Tests.Core
 			_fileSystem = new Mock<IFileSystem>();
 			_fileSystem.Setup(x => x.MapPath(It.IsAny<string>())).Returns<string>(x => x);
 
+			// Per default the output file should not exist, then individual tests
+			// can choose otherwise.
+			_fileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
+
 			_fileCacheHash = new Mock<IFileCacheHash>();
 
 			_babel = new Babel(
@@ -150,6 +154,30 @@ namespace React.Tests.Core
 			var resultFilename = _babel.TransformAndSaveFile("foo.jsx");
 			Assert.AreEqual("foo.generated.js", resultFilename);
 			StringAssert.EndsWith("React.DOM.div('Hello World')", result);
+			System.IO.File.WriteAllText("c:\\temp\\foo.generated.js", result, System.Text.Encoding.UTF8);
+		}
+
+		[Test]
+		public void ShouldSkipTransformationIfCacheIsValid()
+		{
+			_fileSystem.Setup(x => x.ReadAsString("foo.jsx")).Returns("<div>Hello World</div>");
+			_fileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+			_fileCacheHash.Setup(x => x.ValidateHash(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+			_environment.Setup(x => x.ExecuteWithBabel<JavaScriptWithSourceMap>(
+				"ReactNET_transform_sourcemap",
+				It.IsAny<string>(),
+				It.IsAny<string>(), // Babel config
+				"foo.jsx" // File name
+			)).Returns(new JavaScriptWithSourceMap { Code = "React.DOM.div('Hello World')" });
+
+			string result = null;
+			_fileSystem.Setup(x => x.WriteAsString("foo.generated.js", It.IsAny<string>())).Callback(
+				(string filename, string contents) => result = contents
+			);
+
+			var resultFilename = _babel.TransformAndSaveFile("foo.jsx");
+			Assert.AreEqual("foo.generated.js", resultFilename);
+			Assert.IsNull(result, "There should be no result. Cached result should have been used.");
 		}
 
 		private void SetUpEmptyCache()

--- a/src/React.Tests/Core/BabelTransformerTests.cs
+++ b/src/React.Tests/Core/BabelTransformerTests.cs
@@ -154,7 +154,6 @@ namespace React.Tests.Core
 			var resultFilename = _babel.TransformAndSaveFile("foo.jsx");
 			Assert.AreEqual("foo.generated.js", resultFilename);
 			StringAssert.EndsWith("React.DOM.div('Hello World')", result);
-			System.IO.File.WriteAllText("c:\\temp\\foo.generated.js", result, System.Text.Encoding.UTF8);
 		}
 
 		[Test]


### PR DESCRIPTION
In reaction to issue [#299](https://github.com/reactjs/React.NET/issues/299) I have added a hash based check, which then only transpiles the .jsx file if it has actually changed. This shortens build times considerably.