### PR TITLE
updated tutorial to remove early reference

### DIFF
--- a/site/jekyll/getting-started/tutorial.md
+++ b/site/jekyll/getting-started/tutorial.md
@@ -860,7 +860,6 @@ Now that the bundle has been registered, we need to reference it from the view:
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.js"></script>
 	@Scripts.Render("~/bundles/main")
-	@Html.ReactInitJavaScript()
 </body>
 </html>
 ```


### PR DESCRIPTION
Removed a reference to @Html.ReactInitJavaScript() that was added prematurely to the bundling section of the tutorial.  It was not needed until the server-side rendering section.
