### PR TITLE
Fixed a problem registering React assemblies with TinyIoC in some instances

### DIFF
--- a/src/React.Core/Initializer.cs
+++ b/src/React.Core/Initializer.cs
@@ -97,10 +97,10 @@ namespace React
 		private static bool IsReactAssembly(string assemblyName)
 		{
 			return
-				(assemblyName == "React" ||
-				assemblyName.StartsWith("React.") ||
-				assemblyName.EndsWith(".React")) &&
-				!_obsoleteAssemblies.Contains(assemblyName);
+				(assemblyName.Equals("React", StringComparison.OrdinalIgnoreCase) ||
+				assemblyName.StartsWith("React.", StringComparison.OrdinalIgnoreCase) ||
+				assemblyName.EndsWith(".React", StringComparison.OrdinalIgnoreCase)) &&
+				!_obsoleteAssemblies.Contains(assemblyName, StringComparison.OrdinalIgnoreCase);
 		}
 
 		/// <summary>

--- a/src/React.Core/Initializer.cs
+++ b/src/React.Core/Initializer.cs
@@ -100,7 +100,7 @@ namespace React
 				(assemblyName.Equals("React", StringComparison.OrdinalIgnoreCase) ||
 				assemblyName.StartsWith("React.", StringComparison.OrdinalIgnoreCase) ||
 				assemblyName.EndsWith(".React", StringComparison.OrdinalIgnoreCase)) &&
-				!_obsoleteAssemblies.Contains(assemblyName, StringComparison.OrdinalIgnoreCase);
+				!_obsoleteAssemblies.Contains(assemblyName, StringComparer.OrdinalIgnoreCase);
 		}
 
 		/// <summary>


### PR DESCRIPTION
In some instances (unknown cause) RuntimeLibrary names are lower case.
In this case they were failing to register with TinyIoC.

#353 