### PR TITLE
Fixed a problem duplicated relativePath

### DIFF
--- a/src/React.AspNet/AspNetFileSystem.cs
+++ b/src/React.AspNet/AspNetFileSystem.cs
@@ -36,8 +36,12 @@ namespace React.AspNet
 		/// <returns>Full path of the file</returns>
 		public override string MapPath(string relativePath)
 		{
-			relativePath = relativePath.TrimStart('~').TrimStart('/');
-			return Path.Combine(_hostingEnv.WebRootPath, relativePath);
+            if (relativePath.StartsWith(_hostingEnv.WebRootPath))
+            {
+                return relativePath;
+            }
+            relativePath = relativePath.TrimStart('~').TrimStart('/');
+            return Path.Combine(_hostingEnv.WebRootPath, relativePath);
 		}
 	}
 }


### PR DESCRIPTION
I also encountered the same problem, this issue https://github.com/reactjs/React.NET/issues/355
When run ASPdotNET Core app on Windows, it's work well.
Running on Linux (as Docker) or macOS, relative path show "fullpath"
ex)
```
assumed: ~/js/tutorial.jsx
actual: /app/wwwroot/js/tutorial.jsx
```

I tested with tutorial code on Linux(Docker on Windows) microsoft/aspnetcore:1.0.1 and dot net core on Windows via Visual Studio.
When run on Linux, add nuget package  JavaScriptEngineSwitcher.Extentions.MsDependencyInjection and JavaScriptEngineSwitcher.Jint

thanks