### PR TITLE
Switch from NUnit to xUnit

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit.Runners" version="2.6.3" />
-</packages>

--- a/src/React.sln
+++ b/src/React.sln
@@ -23,11 +23,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{CB51F03F
 		template.nuspec = template.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{F2875D3A-0C8A-439B-B734-ECABA00AC629}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "React.Sample.Mvc4", "React.Sample.Mvc4\React.Sample.Mvc4.csproj", "{22796879-968A-4C26-9B4B-4C44792B36DB}"
 	ProjectSection(ProjectDependencies) = postProject
 		{AF531A37-B93F-4113-9C2C-4DB28064B926} = {AF531A37-B93F-4113-9C2C-4DB28064B926}

--- a/tests/React.Tests/Core/BabelTransformerTests.cs
+++ b/tests/React.Tests/Core/BabelTransformerTests.cs
@@ -9,22 +9,20 @@
 
 using System;
 using Moq;
-using NUnit.Framework;
 using React.Exceptions;
+using Xunit;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class BabelTransformerTests
 	{
-		private Mock<IReactEnvironment> _environment;
-		private Mock<ICache> _cache;
-		private Mock<IFileSystem> _fileSystem;
-		private Mock<IFileCacheHash> _fileCacheHash;
-		private Babel _babel;
+		private readonly Mock<IReactEnvironment> _environment;
+		private readonly Mock<ICache> _cache;
+		private readonly Mock<IFileSystem> _fileSystem;
+		private readonly Mock<IFileCacheHash> _fileCacheHash;
+		private readonly Babel _babel;
 
-		[SetUp]
-		public void SetUp()
+		public BabelTransformerTests()
 		{
 			_environment = new Mock<IReactEnvironment>();
 
@@ -47,7 +45,7 @@ namespace React.Tests.Core
 			);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldTransformJsx()
 		{
 			const string input = "<div>Hello World</div>";
@@ -61,7 +59,7 @@ namespace React.Tests.Core
 			));
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldWrapExceptionsInJsxExeption()
 		{
 			_environment.Setup(x => x.ExecuteWithBabel<string>(
@@ -75,7 +73,7 @@ namespace React.Tests.Core
 			Assert.Throws<BabelException>(() => _babel.Transform(input));
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldUseCacheProvider()
 		{
 			_cache.Setup(x => x.Get<JavaScriptWithSourceMap>("JSX_v3_foo.jsx", null)).Returns(new JavaScriptWithSourceMap
@@ -84,10 +82,10 @@ namespace React.Tests.Core
 			});
 
 			var result = _babel.TransformFile("foo.jsx");
-			Assert.AreEqual("/* cached */", result);
+			Assert.Equal("/* cached */", result);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldUseFileSystemCacheIfHashValid()
 		{
 			SetUpEmptyCache();
@@ -96,10 +94,10 @@ namespace React.Tests.Core
 			_fileCacheHash.Setup(x => x.ValidateHash(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
 
 			var result = _babel.TransformFile("foo.jsx");
-			Assert.AreEqual("/* filesystem cached */", result);
+			Assert.Equal("/* filesystem cached */", result);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldTransformJsxIfFileCacheHashInvalid()
 		{
 			SetUpEmptyCache();
@@ -115,10 +113,10 @@ namespace React.Tests.Core
 			)).Returns(new JavaScriptWithSourceMap { Code = "React.DOM.div('Hello World')" });
 
 			var result = _babel.TransformFile("foo.jsx");
-			StringAssert.EndsWith("React.DOM.div('Hello World')", result);
+			Assert.EndsWith("React.DOM.div('Hello World')", result);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldTransformJsxIfNoCache()
 		{
 			SetUpEmptyCache();
@@ -132,10 +130,10 @@ namespace React.Tests.Core
 			)).Returns(new JavaScriptWithSourceMap { Code = "React.DOM.div('Hello World')" });
 
 			var result = _babel.TransformFile("foo.jsx");
-			StringAssert.EndsWith("React.DOM.div('Hello World')", result);
+			Assert.EndsWith("React.DOM.div('Hello World')", result);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldSaveTransformationResult()
 		{
 			_fileSystem.Setup(x => x.ReadAsString("foo.jsx")).Returns("<div>Hello World</div>");
@@ -152,11 +150,11 @@ namespace React.Tests.Core
 			);
 
 			var resultFilename = _babel.TransformAndSaveFile("foo.jsx");
-			Assert.AreEqual("foo.generated.js", resultFilename);
-			StringAssert.EndsWith("React.DOM.div('Hello World')", result);
+			Assert.Equal("foo.generated.js", resultFilename);
+			Assert.EndsWith("React.DOM.div('Hello World')", result);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldSkipTransformationIfCacheIsValid()
 		{
 			_fileSystem.Setup(x => x.ReadAsString("foo.jsx")).Returns("<div>Hello World</div>");
@@ -175,8 +173,9 @@ namespace React.Tests.Core
 			);
 
 			var resultFilename = _babel.TransformAndSaveFile("foo.jsx");
-			Assert.AreEqual("foo.generated.js", resultFilename);
-			Assert.IsNull(result, "There should be no result. Cached result should have been used.");
+			Assert.Equal("foo.generated.js", resultFilename);
+            // There should be no result. Cached result should have been used.
+            Assert.Null(result);
 		}
 
 		private void SetUpEmptyCache()

--- a/tests/React.Tests/Core/FileCacheHashTests.cs
+++ b/tests/React.Tests/Core/FileCacheHashTests.cs
@@ -7,55 +7,54 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using NUnit.Framework;
+using Xunit;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class FileCacheHashTests
 	{
 		private const string SAMPLE_HASH = "0A4D55A8D778E5022FAB701977C5D840BBC486D0";
 
-		[Test]
+		[Fact]
 		public void TestCalculateHash()
 		{
 			var hash = new FileCacheHash();
-			Assert.AreEqual(SAMPLE_HASH, hash.CalculateHash("Hello World"));
+			Assert.Equal(SAMPLE_HASH, hash.CalculateHash("Hello World"));
 		}
 
-		[Test]
+		[Fact]
 		public void ValidateHashShouldReturnFalseForEmptyString()
 		{
 			var hash = new FileCacheHash();
-			Assert.IsFalse(hash.ValidateHash(string.Empty, SAMPLE_HASH));
+			Assert.False(hash.ValidateHash(string.Empty, SAMPLE_HASH));
 		}
 
-		[Test]
+		[Fact]
 		public void ValidateHashShouldReturnFalseForNull()
 		{
 			var hash = new FileCacheHash();
-			Assert.IsFalse(hash.ValidateHash(null, SAMPLE_HASH));
+			Assert.False(hash.ValidateHash(null, SAMPLE_HASH));
 		}
 
-		[Test]
+		[Fact]
 		public void ValidateHashShouldReturnFalseWhenNoHashPrefix()
 		{
 			var hash = new FileCacheHash();
-			Assert.IsFalse(hash.ValidateHash("Hello World", SAMPLE_HASH));
+			Assert.False(hash.ValidateHash("Hello World", SAMPLE_HASH));
 		}
 
-		[Test]
+		[Fact]
 		public void ValidateHashShouldReturnFalseWhenHashDoesNotMatch()
 		{
 			var hash = new FileCacheHash();
-			Assert.IsFalse(hash.ValidateHash("// @hash NOTCORRECT\nHello World", SAMPLE_HASH));
+			Assert.False(hash.ValidateHash("// @hash NOTCORRECT\nHello World", SAMPLE_HASH));
 		}
 
-		[Test]
+		[Fact]
 		public void ValidateHashShouldReturnTrueWhenHashMatches()
 		{
 			var hash = new FileCacheHash();
-			Assert.IsTrue(hash.ValidateHash("// @hash v3-" + SAMPLE_HASH + "\nHello World", SAMPLE_HASH));
+			Assert.True(hash.ValidateHash("// @hash v3-" + SAMPLE_HASH + "\nHello World", SAMPLE_HASH));
 		}
 	}
 }

--- a/tests/React.Tests/Core/FileSystemBaseTests.cs
+++ b/tests/React.Tests/Core/FileSystemBaseTests.cs
@@ -7,19 +7,19 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using NUnit.Framework;
+using Xunit;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class FileSystemBaseTests
 	{
-		[TestCase("~/Test.txt", "C:\\Test.txt")]
-		[TestCase("~/Scripts/lol.js", "C:\\Scripts\\lol.js")]
+        [Theory]
+		[InlineData("~/Test.txt", "C:\\Test.txt")]
+		[InlineData("~/Scripts/lol.js", "C:\\Scripts\\lol.js")]
 		public void ToRelativePath(string expected, string input)
 		{
 			var fileSystem = new TestFileSystem();
-			Assert.AreEqual(expected, fileSystem.ToRelativePath(input));
+			Assert.Equal(expected, fileSystem.ToRelativePath(input));
 		}
 
 		private class TestFileSystem : FileSystemBase

--- a/tests/React.Tests/Core/FileSystemExtensionsTest.cs
+++ b/tests/React.Tests/Core/FileSystemExtensionsTest.cs
@@ -7,22 +7,22 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using NUnit.Framework;
+using Xunit;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class FileSystemExtensionsTests
 	{
-		[TestCase("*.txt", true)]
-		[TestCase("foo?.js", true)]
-		[TestCase("first\\second\\third\\*.js", true)]
-		[TestCase("lol.js", false)]
-		[TestCase("", false)]
-		[TestCase("hello\\world.js", false)]
+        [Theory]
+        [InlineData("*.txt", true)]
+		[InlineData("foo?.js", true)]
+		[InlineData("first\\second\\third\\*.js", true)]
+		[InlineData("lol.js", false)]
+		[InlineData("", false)]
+		[InlineData("hello\\world.js", false)]
 		public void IsGlobPattern(string input, bool expected)
 		{
-			Assert.AreEqual(expected, input.IsGlobPattern());
+			Assert.Equal(expected, input.IsGlobPattern());
 		}
 	}
 }

--- a/tests/React.Tests/Core/GuidExtensionsTests.cs
+++ b/tests/React.Tests/Core/GuidExtensionsTests.cs
@@ -8,18 +8,17 @@
  */
 
 using System;
-using NUnit.Framework;
+using Xunit;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class GuidExtensionsTests
 	{
-		[TestCase]
+		[Fact]
 		public void ToShortGuid()
 		{
 			var guid = Guid.Parse("c027191d-3785-485d-9fd7-5e0b376bd547");
-			Assert.AreEqual("HRknwIU3XUif114LN2vVRw", guid.ToShortGuid());
+			Assert.Equal("HRknwIU3XUif114LN2vVRw", guid.ToShortGuid());
 		}
 	}
 }

--- a/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
+++ b/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
@@ -12,12 +12,11 @@ using System.Collections.Generic;
 using System.Threading;
 using JavaScriptEngineSwitcher.Core;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 using React.Exceptions;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class JavaScriptEngineFactoryTest
 	{
 		private JavaScriptEngineFactory CreateBasicFactory()
@@ -52,23 +51,18 @@ namespace React.Tests.Core
 			return new JavaScriptEngineFactory(JsEngineSwitcher.Instance, config.Object, fileSystem.Object);
 		}
 
-		[SetUp]
-		public void BeforeEach()
-		{
-		}
-
-		[Test]
+		[Fact]
 		public void ShouldReturnSameEngine()
 		{
 			var factory = CreateBasicFactory();
 			var engine1 = factory.GetEngineForCurrentThread();
 			var engine2 = factory.GetEngineForCurrentThread();
 			
-			Assert.AreEqual(engine1, engine2);
+			Assert.Equal(engine1, engine2);
 			factory.DisposeEngineForCurrentThread();
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldReturnNewEngineAfterDisposing()
 		{
 			var factory = CreateBasicFactory();
@@ -77,10 +71,10 @@ namespace React.Tests.Core
 			var engine2 = factory.GetEngineForCurrentThread();
 			factory.DisposeEngineForCurrentThread();
 
-			Assert.AreNotEqual(engine1, engine2);
+			Assert.NotEqual(engine1, engine2);
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldCreateNewEngineForNewThread()
 		{
 			var factory = CreateBasicFactory();
@@ -99,13 +93,13 @@ namespace React.Tests.Core
 			var engine3 = factory.GetEngineForCurrentThread();
 
 			// Different threads should have different engines
-			Assert.AreNotEqual(engine1, engine2);
+			Assert.NotEqual(engine1, engine2);
 			// Same thread should share same engine
-			Assert.AreEqual(engine1, engine3);
+			Assert.Equal(engine1, engine3);
 			factory.DisposeEngineForCurrentThread();
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldLoadFilesThatDoNotRequireTransform()
 		{
 			var jsEngine = new Mock<IJsEngine>();
@@ -126,7 +120,7 @@ namespace React.Tests.Core
 			jsEngine.Verify(x => x.Execute("CONTENTS_Second.js"));
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldHandleLoadingExternalReactVersion()
 		{
 			var jsEngine = new Mock<IJsEngine>();
@@ -143,7 +137,7 @@ namespace React.Tests.Core
 			jsEngine.Verify(x => x.CallFunction<bool>("ReactNET_initReact"));
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldThrowIfReactVersionNotLoaded()
 		{
 			var jsEngine = new Mock<IJsEngine>();
@@ -161,7 +155,7 @@ namespace React.Tests.Core
 			});
 		}
 
-		[Test]
+		[Fact]
 		public void ShouldCatchErrorsWhileLoadingScripts()
 		{
 			var config = new Mock<IReactSiteConfiguration>();
@@ -180,7 +174,7 @@ namespace React.Tests.Core
 			var factory = CreateFactory(config, fileSystem, () => jsEngine.Object);
 
 			var ex = Assert.Throws<ReactScriptLoadException>(() => factory.GetEngineForCurrentThread());
-			Assert.AreEqual("Error while loading \"foo.js\": Fail\r\nLine: 42\r\nColumn: 911", ex.Message);
+			Assert.Equal("Error while loading \"foo.js\": Fail\r\nLine: 42\r\nColumn: 911", ex.Message);
 		}
 	}
 }

--- a/tests/React.Tests/Core/JavaScriptEngineUtilsTests.cs
+++ b/tests/React.Tests/Core/JavaScriptEngineUtilsTests.cs
@@ -9,15 +9,14 @@
 
 using JavaScriptEngineSwitcher.Core;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 using React.Exceptions;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class JavaScriptEngineUtilsTests
 	{
-		[Test]
+		[Fact]
 		public void CallFunctionReturningJsonHandlesScalarReturnValue()
 		{
 			var engine = new Mock<IJsEngine>();
@@ -25,16 +24,16 @@ namespace React.Tests.Core
 			engine.Verify(x => x.CallFunction<int>("hello"));
 		}
 
-		[Test]
+		[Fact]
 		public void CallFunctionReturningJsonHandlesJson()
 		{
 			var engine = new Mock<IJsEngine>();
 			engine.Setup(x => x.CallFunction<string>("hello")).Returns("{\"message\":\"Hello World\"}");
 			var result = engine.Object.CallFunctionReturningJson<Example>("hello");
-			Assert.AreEqual("Hello World", result.Message);
+			Assert.Equal("Hello World", result.Message);
 		}
 
-		[Test]
+		[Fact]
 		public void CallFunctionReturningJsonThrowsOnInvalidJson()
 		{
 			var engine = new Mock<IJsEngine>();

--- a/tests/React.Tests/Core/ReactComponentTest.cs
+++ b/tests/React.Tests/Core/ReactComponentTest.cs
@@ -8,15 +8,14 @@
  */
 
 using Moq;
-using NUnit.Framework;
+using Xunit;
 using React.Exceptions;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class ReactComponentTest
 	{
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldThrowExceptionIfComponentDoesNotExist()
 		{
 			var environment = new Mock<IReactEnvironment>();
@@ -31,7 +30,7 @@ namespace React.Tests.Core
 			});
 		}
 
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldCallRenderComponent()
 		{
 			var environment = new Mock<IReactEnvironment>();
@@ -48,7 +47,7 @@ namespace React.Tests.Core
 			environment.Verify(x => x.Execute<string>(@"ReactDOMServer.renderToString(React.createElement(Foo, {""hello"":""World""}))"));
 		}
 
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldWrapComponentInDiv()
 		{
 			var environment = new Mock<IReactEnvironment>();
@@ -64,10 +63,10 @@ namespace React.Tests.Core
 			};
 			var result = component.RenderHtml();
 
-			Assert.AreEqual(@"<div id=""container"">[HTML]</div>", result);
+			Assert.Equal(@"<div id=""container"">[HTML]</div>", result);
 		}
 
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldNotRenderComponentHtml()
 		{
 			var environment = new Mock<IReactEnvironment>();
@@ -82,11 +81,11 @@ namespace React.Tests.Core
 			};
 			var result = component.RenderHtml(renderContainerOnly: true);
 
-			Assert.AreEqual(@"<div id=""container""></div>", result);
+			Assert.Equal(@"<div id=""container""></div>", result);
 			environment.Verify(x => x.Execute(It.IsAny<string>()), Times.Never);
 		}
 
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldNotRenderClientSideAttributes()
 		{
 			var environment = new Mock<IReactEnvironment>();
@@ -103,7 +102,7 @@ namespace React.Tests.Core
 			environment.Verify(x => x.Execute<string>(@"ReactDOMServer.renderToStaticMarkup(React.createElement(Foo, {""hello"":""World""}))"));
 		}
 
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldWrapComponentInCustomElement()
 		{
 			var config = new Mock<IReactSiteConfiguration>();
@@ -120,10 +119,10 @@ namespace React.Tests.Core
 			};
 			var result = component.RenderHtml();
 
-			Assert.AreEqual(@"<span id=""container"">[HTML]</span>", result);
+			Assert.Equal(@"<span id=""container"">[HTML]</span>", result);
 		}
 
-		[Test]
+		[Fact]
 		public void RenderHtmlShouldAddClassToElement()
 		{
 			var config = new Mock<IReactSiteConfiguration>();
@@ -140,10 +139,10 @@ namespace React.Tests.Core
 			};
 			var result = component.RenderHtml();
 
-			Assert.AreEqual(@"<div id=""container"" class=""test-class"">[HTML]</div>", result);
+			Assert.Equal(@"<div id=""container"" class=""test-class"">[HTML]</div>", result);
 		}
 
-		[Test]
+		[Fact]
 		public void RenderJavaScriptShouldCallRenderComponent()
 		{
 			var environment = new Mock<IReactEnvironment>();
@@ -155,18 +154,19 @@ namespace React.Tests.Core
 			};
 			var result = component.RenderJavaScript();
 
-			Assert.AreEqual(
+			Assert.Equal(
 				@"ReactDOM.render(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
 				result
 			);
 		}
 
-		[TestCase("Foo", true)]
-		[TestCase("Foo.Bar", true)]
-		[TestCase("Foo.Bar.Baz", true)]
-		[TestCase("alert()", false)]
-		[TestCase("Foo.alert()", false)]
-		[TestCase("lol what", false)]
+        [Theory]
+		[InlineData("Foo", true)]
+		[InlineData("Foo.Bar", true)]
+		[InlineData("Foo.Bar.Baz", true)]
+		[InlineData("alert()", false)]
+		[InlineData("Foo.alert()", false)]
+		[InlineData("lol what", false)]
 		public void TestEnsureComponentNameValid(string input, bool expected)
 		{
 			var isValid = true;
@@ -178,18 +178,18 @@ namespace React.Tests.Core
 			{
 				isValid =  false;
 			}
-			Assert.AreEqual(expected, isValid);
+			Assert.Equal(expected, isValid);
 		}
 
 
-		[Test]
+		[Fact]
 		public void GeneratesContainerIdIfNotProvided()
 		{
 			var environment = new Mock<IReactEnvironment>();
 			var config = new Mock<IReactSiteConfiguration>();
 
 			var component = new ReactComponent(environment.Object, config.Object, "Foo", null);
-			StringAssert.StartsWith("react_", component.ContainerId);
+			Assert.StartsWith("react_", component.ContainerId);
 		}
 
 	}

--- a/tests/React.Tests/Core/ReactEnvironmentTest.cs
+++ b/tests/React.Tests/Core/ReactEnvironmentTest.cs
@@ -12,15 +12,14 @@ using System.Collections.Generic;
 using System.Linq;
 using JavaScriptEngineSwitcher.Core;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 using React.Exceptions;
 
 namespace React.Tests.Core
 {
-	[TestFixture]
 	public class ReactEnvironmentTest
 	{
-		[Test]
+		[Fact]
 		public void ExecuteWithBabelWithNoNewThread()
 		{
 			var mocks = new Mocks();
@@ -30,7 +29,7 @@ namespace React.Tests.Core
 			mocks.Engine.Verify(x => x.CallFunction<int>("foo"), Times.Exactly(1));
 		}
 
-		[Test]
+		[Fact]
 		public void ExecuteWithBabelWithNewThread()
 		{
 			var mocks = new Mocks();
@@ -54,7 +53,7 @@ namespace React.Tests.Core
 			);
 		}
 
-		[Test]
+		[Fact]
 		public void ExecuteWithBabelShouldBubbleExceptions()
 		{
 			var mocks = new Mocks();
@@ -69,7 +68,7 @@ namespace React.Tests.Core
 			});
 		}
 
-		[Test]
+		[Fact]
 		public void ExecuteWithBabelShouldThrowIfBabelDisabled()
 		{
 			var mocks = new Mocks();
@@ -82,7 +81,7 @@ namespace React.Tests.Core
 			});
 		}
 
-		[Test]
+		[Fact]
 		public void GeneratesContainerIdIfNotProvided()
 		{
 			var mocks = new Mocks();
@@ -91,11 +90,11 @@ namespace React.Tests.Core
 
 			var component1 = environment.CreateComponent("ComponentName", new { });
 			var component2 = environment.CreateComponent("ComponentName", new { });
-			StringAssert.StartsWith("react_", component1.ContainerId);
-			StringAssert.StartsWith("react_", component2.ContainerId);
+			Assert.StartsWith("react_", component1.ContainerId);
+			Assert.StartsWith("react_", component2.ContainerId);
 		}
 
-		[Test]
+		[Fact]
 		public void UsesProvidedContainerId()
 		{
 			var mocks = new Mocks();
@@ -104,11 +103,11 @@ namespace React.Tests.Core
 
 			var component1 = environment.CreateComponent("ComponentName", new { }, "foo");
 			var component2 = environment.CreateComponent("ComponentName", new { });
-			Assert.AreEqual("foo", component1.ContainerId);
-			StringAssert.StartsWith("react_", component2.ContainerId);
+			Assert.Equal("foo", component1.ContainerId);
+			Assert.StartsWith("react_", component2.ContainerId);
 		}
 
-		[Test]
+		[Fact]
 		public void ReturnsEngineToPool()
 		{
 			var mocks = new Mocks();

--- a/tests/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/tests/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -7,14 +7,12 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using System.Runtime.Remoting;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 using React.Web.Mvc;
 
 namespace React.Tests.Mvc
 {
-	[TestFixture]
 	class HtmlHelperExtensionsTests
 	{
 		/// <summary>
@@ -29,7 +27,7 @@ namespace React.Tests.Mvc
 			return environment;
 		}
 
-		[Test]
+		[Fact]
 		public void ReactWithInitShouldReturnHtmlAndScript()
 		{
 			var component = new Mock<IReactComponent>();
@@ -49,13 +47,13 @@ namespace React.Tests.Mvc
 				props: new { },
 				htmlTag: "span"
 			);
-			Assert.AreEqual(
+			Assert.Equal(
 				"HTML" + System.Environment.NewLine + "<script>JS</script>",
 				result.ToString()
 			);
 		}
 
-		[Test]
+		[Fact]
 		public void EngineIsReturnedToPoolAfterRender()
 		{
 			var component = new Mock<IReactComponent>();
@@ -81,7 +79,7 @@ namespace React.Tests.Mvc
 			environment.Verify(x => x.ReturnEngineToPool(), Times.Once);
 		}
 
-		[Test]
+		[Fact]
 		public void ReactWithClientOnlyTrueShouldCallRenderHtmlWithTrue()
 		{
 			var component = new Mock<IReactComponent>();
@@ -105,7 +103,7 @@ namespace React.Tests.Mvc
 			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == true)), Times.Once);
 		}
 
-		[Test]
+		[Fact]
 		public void ReactWithServerOnlyTrueShouldCallRenderHtmlWithTrue() {
 			var component = new Mock<IReactComponent>();
 			component.Setup(x => x.RenderHtml(true, true)).Returns("HTML");

--- a/tests/React.Tests/Owin/EntryAssemblyFileSystemTests.cs
+++ b/tests/React.Tests/Owin/EntryAssemblyFileSystemTests.cs
@@ -7,21 +7,21 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using NUnit.Framework;
+using Xunit;
 using React.Owin;
 
 namespace React.Tests.Owin
 {
-	[TestFixture]
 	public class EntryAssemblyFileSystemTests
 	{
-		[TestCase("C:\\", "~/", "C:\\")]
-		[TestCase("C:\\", "~/foo/bar.js", "C:\\foo\\bar.js")]
+        [Theory]
+		[InlineData("C:\\", "~/", "C:\\")]
+		[InlineData("C:\\", "~/foo/bar.js", "C:\\foo\\bar.js")]
 		public void MapPath(string rootPath, string relativePath, string expected)
 		{
 			var fileSystem = new EntryAssemblyFileSystem(rootPath);
 			var result = fileSystem.MapPath(relativePath);
-			Assert.AreEqual(expected, result);
+			Assert.Equal(expected, result);
 		}
 	}
 }

--- a/tests/React.Tests/project.json
+++ b/tests/React.Tests/project.json
@@ -7,11 +7,10 @@
   "buildOptions": {
     "keyFile": "../../src/key.snk"
   },
-
   "dependencies": {
-    "dotnet-test-nunit": "3.4.0-beta-2",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.5.30",
-    "NUnit": "3.6.0",
+    "xunit": "2.3.0-beta1-build3642",
     "React.Core": {
       "target": "project"
     },
@@ -22,9 +21,8 @@
       "target": "project"
     }
   },
-
   "frameworks": {
     "net451": {}
   },
-  "testRunner": "nunit"
+  "testRunner": "xunit"
 }


### PR DESCRIPTION
xUnit is easier to use in newer versions of .NET Core, as NUnit hasn't been updated to support them yet.