### PR TITLE
Upgrade to JSPool 3.0

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -10,8 +10,8 @@ of patent rights can be found in the PATENTS file in the same directory.
 <Project ToolsVersion="4.0" DefaultTargets="Build;Test;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Major>3</Major>
-		<Minor>0</Minor>
-		<Build>1</Build>
+		<Minor>1</Minor>
+		<Build>0</Build>
 		<Revision>0</Revision>
 		<DevNuGetServer>http://reactjs.net/packages/</DevNuGetServer>
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\tools\MSBuildTasks</MSBuildCommunityTasksPath>

--- a/src/React.Core/IJavaScriptEngineFactory.cs
+++ b/src/React.Core/IJavaScriptEngineFactory.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using JavaScriptEngineSwitcher.Core;
+﻿using JavaScriptEngineSwitcher.Core;
+using JSPool;
 
 namespace React
 {
@@ -25,12 +25,12 @@ namespace React
 		/// Gets a JavaScript engine from the pool.
 		/// </summary>
 		/// <returns>The JavaScript engine</returns>
-		IJsEngine GetEngine();
+		PooledJsEngine GetEngine();
 
 		/// <summary>
 		/// Returns an engine to the pool so it can be reused
 		/// </summary>
 		/// <param name="engine">Engine to return</param>
-		void ReturnEngineToPool(IJsEngine engine);
+		void ReturnEngineToPool(PooledJsEngine engine);
 	}
 }

--- a/src/React.Core/IJavaScriptEngineFactory.cs
+++ b/src/React.Core/IJavaScriptEngineFactory.cs
@@ -26,11 +26,5 @@ namespace React
 		/// </summary>
 		/// <returns>The JavaScript engine</returns>
 		PooledJsEngine GetEngine();
-
-		/// <summary>
-		/// Returns an engine to the pool so it can be reused
-		/// </summary>
-		/// <param name="engine">Engine to return</param>
-		void ReturnEngineToPool(PooledJsEngine engine);
 	}
 }

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -223,7 +223,7 @@ namespace React
 		/// Gets a JavaScript engine from the pool.
 		/// </summary>
 		/// <returns>The JavaScript engine</returns>
-		public virtual IJsEngine GetEngine()
+		public virtual PooledJsEngine GetEngine()
 		{
 			EnsureValidState();
 			return _pool.GetEngine();
@@ -233,13 +233,13 @@ namespace React
 		/// Returns an engine to the pool so it can be reused
 		/// </summary>
 		/// <param name="engine">Engine to return</param>
-		public virtual void ReturnEngineToPool(IJsEngine engine)
+		public virtual void ReturnEngineToPool(PooledJsEngine engine)
 		{
 			// This could be called from ReactEnvironment.Dispose if that class is disposed after 
 			// this class. Let's just ignore this if it's disposed.
 			if (!_disposed)
 			{
-				_pool.ReturnEngineToPool(engine);	
+				engine.Dispose();
 			}
 		}
 

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -230,20 +230,6 @@ namespace React
 		}
 
 		/// <summary>
-		/// Returns an engine to the pool so it can be reused
-		/// </summary>
-		/// <param name="engine">Engine to return</param>
-		public virtual void ReturnEngineToPool(PooledJsEngine engine)
-		{
-			// This could be called from ReactEnvironment.Dispose if that class is disposed after 
-			// this class. Let's just ignore this if it's disposed.
-			if (!_disposed)
-			{
-				engine.Dispose();
-			}
-		}
-
-		/// <summary>
 		/// Gets a factory for the most appropriate JavaScript engine for the current environment.
 		/// The first functioning JavaScript engine with the lowest priority will be used.
 		/// </summary>

--- a/src/React.Core/React.Core.csproj
+++ b/src/React.Core/React.Core.csproj
@@ -26,16 +26,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="2.3.2" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="2.2.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="2.3.2" />
-    <PackageReference Include="JSPool" Version="2.0.1" />
-    <PackageReference Include="MsieJavaScriptEngine" Version="2.1.2" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="2.4.8" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="2.4.9" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="2.4.9" />
+    <PackageReference Include="JSPool" Version="3.0.1" />
+    <PackageReference Include="MsieJavaScriptEngine" Version="2.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.2.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.4.2" />
     <PackageReference Include="VroomJs" Version="1.2.3" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System" />

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 using JavaScriptEngineSwitcher.Core;
 using JavaScriptEngineSwitcher.Core.Helpers;
+using JSPool;
 using Newtonsoft.Json;
 using React.Exceptions;
 
@@ -68,7 +69,7 @@ namespace React
 		/// Contains an engine acquired from a pool of engines. Only used if 
 		/// <see cref="IReactSiteConfiguration.ReuseJavaScriptEngines"/> is enabled.
 		/// </summary>
-		protected Lazy<IJsEngine> _engineFromPool;
+		protected Lazy<PooledJsEngine> _engineFromPool;
 
 		/// <summary>
 		/// List of all components instantiated in this environment
@@ -108,7 +109,7 @@ namespace React
 			_babelTransformer = new Lazy<IBabel>(() => 
 				new Babel(this, _cache, _fileSystem, _fileCacheHash, _config)
 			);
-			_engineFromPool = new Lazy<IJsEngine>(() => _engineFactory.GetEngine());
+			_engineFromPool = new Lazy<PooledJsEngine>(() => _engineFactory.GetEngine());
 		}
 
 		/// <summary>
@@ -400,7 +401,7 @@ namespace React
 			if (_engineFromPool.IsValueCreated)
 			{
 				_engineFactory.ReturnEngineToPool(_engineFromPool.Value);
-				_engineFromPool = new Lazy<IJsEngine>(() => _engineFactory.GetEngine());
+				_engineFromPool = new Lazy<PooledJsEngine>(() => _engineFactory.GetEngine());
 			}
 		}
 

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -400,7 +400,7 @@ namespace React
 		{
 			if (_engineFromPool.IsValueCreated)
 			{
-				_engineFactory.ReturnEngineToPool(_engineFromPool.Value);
+				_engineFromPool.Value.Dispose();
 				_engineFromPool = new Lazy<PooledJsEngine>(() => _engineFactory.GetEngine());
 			}
 		}

--- a/src/React.MSBuild/AssemblyBindingRedirect.cs
+++ b/src/React.MSBuild/AssemblyBindingRedirect.cs
@@ -1,0 +1,86 @@
+﻿/*
+ *  Copyright (c) 2017-Present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace React.MSBuild
+{
+	/// <summary>
+	/// Hacks around the fact that it's not possible to do assembly binding redirects in MSBuild.
+	/// 
+	/// https://github.com/Microsoft/msbuild/issues/1309
+	/// http://blog.slaks.net/2013-12-25/redirecting-assembly-loads-at-runtime/
+	/// </summary>
+	public static class AssemblyBindingRedirect
+	{
+		/// <summary>
+		/// Redirects that have been configured
+		/// </summary>
+		private static readonly Dictionary<string, Version> _redirects = new Dictionary<string, Version>();
+
+	    static AssemblyBindingRedirect()
+	    {
+			// This is in a static constructor because it needs to run as early as possible
+		    ConfigureRedirect("JavaScriptEngineSwitcher.Core");
+			AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
+		}
+
+		/// <summary>
+		/// Enables assembly binding redirects
+		/// </summary>
+	    public static void Enable()
+	    {
+			// Intentionally empty.  This is just meant to ensure the static constructor
+			// has run.
+		}
+
+		/// <summary>
+		/// Configures a redirect for the specified assembly. Redirects to the version in the bin directory.
+		/// </summary>
+		/// <param name="name">Name of the assembly to redirect</param>
+		private static void ConfigureRedirect(string name)
+		{
+			var currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
+			var redirectAssemblyPath = Path.Combine(
+				Path.GetDirectoryName(currentAssemblyPath),
+				name + ".dll"
+			);
+
+			try
+			{
+				var realAssembly = Assembly.LoadFile(redirectAssemblyPath);
+				var version = realAssembly.GetName().Version;
+				_redirects[name] = version;
+			}
+			catch (Exception ex)
+			{
+				Trace.WriteLine("Warning: Could not determine version of " + name + " to use! " + ex.Message);
+			}
+		}
+
+		/// <summary>
+		/// Overrides assembly resolution to redirect if necessary.
+		/// </summary>
+		private static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+		{
+			var requestedAssembly = new AssemblyName(args.Name);
+
+			if (_redirects.ContainsKey(requestedAssembly.Name) && requestedAssembly.Version != _redirects[requestedAssembly.Name])
+			{
+				requestedAssembly.Version = _redirects[requestedAssembly.Name];
+				return Assembly.Load(requestedAssembly);
+			}
+			return null;
+		}
+	}
+}

--- a/src/React.MSBuild/MSBuildHost.cs
+++ b/src/React.MSBuild/MSBuildHost.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace React.MSBuild
 {
@@ -36,6 +37,8 @@ namespace React.MSBuild
 		/// <returns></returns>
 		private static bool Initialize()
 		{
+			AssemblyBindingRedirect.Enable();
+
 			// All "per-request" registrations should be singletons in MSBuild, since there's no
 			// such thing as a "request"
 			Initializer.Initialize(requestLifetimeRegistration: registration => registration.AsSingleton());

--- a/src/React.Sample.Cassette/React.Sample.Cassette.csproj
+++ b/src/React.Sample.Cassette/React.Sample.Cassette.csproj
@@ -68,9 +68,8 @@
       <HintPath>..\packages\Cassette.Views.2.4.2\lib\net40\Cassette.Views.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.2.0\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/React.Sample.Cassette/Web.config
+++ b/src/React.Sample.Cassette/Web.config
@@ -62,7 +62,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.4.9.0" newVersion="2.4.9.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/src/React.Sample.Cassette/packages.config
+++ b/src/React.Sample.Cassette/packages.config
@@ -5,7 +5,7 @@
   <package id="Cassette.Aspnet" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.MSBuild" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Views" version="2.4.2" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.Core" version="2.2.0" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />

--- a/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
+++ b/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
@@ -57,26 +57,21 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClearScript, Version=5.4.8.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.2.0\lib\net45\ClearScript.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ClearScript, Version=5.4.9.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net45\ClearScript.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.2.0\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Msie, Version=2.3.2.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.2.3.2\lib\net45\JavaScriptEngineSwitcher.Msie.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JavaScriptEngineSwitcher.Msie, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.2.4.9\lib\net45\JavaScriptEngineSwitcher.Msie.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.2.0\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.4.2.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MsieJavaScriptEngine, Version=2.1.2.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
-      <HintPath>..\packages\MsieJavaScriptEngine.2.1.2\lib\net45\MsieJavaScriptEngine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MsieJavaScriptEngine, Version=2.2.2.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MsieJavaScriptEngine.2.2.2\lib\net45\MsieJavaScriptEngine.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/React.Sample.Mvc4/Web.config
+++ b/src/React.Sample.Mvc4/Web.config
@@ -92,6 +92,10 @@
         <assemblyIdentity name="JavaScriptEngineSwitcher.Msie" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="a3a2846a37ac0d3e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.2.0" newVersion="2.2.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 

--- a/src/React.Sample.Mvc4/Web.config
+++ b/src/React.Sample.Mvc4/Web.config
@@ -74,7 +74,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.9.0" newVersion="2.4.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/src/React.Sample.Mvc4/packages.config
+++ b/src/React.Sample.Mvc4/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.Core" version="2.2.0" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.Msie" version="2.3.2" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8" version="2.2.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.Msie" version="2.4.9" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8" version="2.4.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net4" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net4" />
-  <package id="MsieJavaScriptEngine" version="2.1.2" targetFramework="net45" />
+  <package id="MsieJavaScriptEngine" version="2.2.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />

--- a/src/React.Sample.Mvc6/React.Sample.Mvc6.csproj
+++ b/src/React.Sample.Mvc6/React.Sample.Mvc6.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.2.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.4.2" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/React.Sample.Webpack/React.Sample.Webpack.csproj
+++ b/src/React.Sample.Webpack/React.Sample.Webpack.csproj
@@ -50,17 +50,14 @@
     <NoWarn>1607</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ClearScript, Version=5.4.8.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.2.0\lib\net40-client\ClearScript.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ClearScript, Version=5.4.9.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net40-client\ClearScript.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.2.0\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.2.0\lib\net40-client\JavaScriptEngineSwitcher.V8.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.4.2.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net40-client\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/React.Sample.Webpack/Web.config
+++ b/src/React.Sample.Webpack/Web.config
@@ -56,7 +56,7 @@
 			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.9.0" newVersion="2.4.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />

--- a/src/React.Sample.Webpack/packages.config
+++ b/src/React.Sample.Webpack/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JavaScriptEngineSwitcher.Core" version="2.2.0" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.V8" version="2.2.0" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.V8" version="2.4.2" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />

--- a/tests/React.Tests/Core/ReactEnvironmentTest.cs
+++ b/tests/React.Tests/Core/ReactEnvironmentTest.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JavaScriptEngineSwitcher.Core;
+using JSPool;
 using Moq;
 using Xunit;
 using React.Exceptions;
@@ -124,7 +125,7 @@ namespace React.Tests.Core
 
 		private class Mocks
 		{
-			public Mock<IJsEngine> Engine { get; private set; }
+			public Mock<PooledJsEngine> Engine { get; private set; }
 			public Mock<IJavaScriptEngineFactory> EngineFactory { get; private set; }
 			public Mock<IReactSiteConfiguration> Config { get; private set; }
 			public Mock<ICache> Cache { get; private set; }
@@ -132,7 +133,7 @@ namespace React.Tests.Core
 			public Mock<IFileCacheHash> FileCacheHash { get; private set; }
 			public Mocks()
 			{
-				Engine = new Mock<IJsEngine>();
+				Engine = new Mock<PooledJsEngine>();
 				EngineFactory = new Mock<IJavaScriptEngineFactory>();
 				Config = new Mock<IReactSiteConfiguration>();
 				Cache = new Mock<ICache>();


### PR DESCRIPTION
Upgrades ReactJS.NET to use JSPool 3.0, and updates all JavaScriptEngineSwitcher dependencies to their latest versions

Also adds an assembly redirect hack for MSBuild so that it can correctly load `JavaScriptEngineSwitcher.Core` when `JavaScriptEngineSwitcher.V8` references an older version. Normally this would be done in `Web.config` or `app.config` as an assembly redirect, but that does not work in MSBuild. The only way to do it in MSBuild is to manually redirect the assembly.