### PR TITLE
Update libraries for .NET Core to 2.0 and for .NET Standard to 2.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "projects": [ "src", "test" ]
 }

--- a/src/React.AspNet.Middleware/AssemblyRegistration.cs
+++ b/src/React.AspNet.Middleware/AssemblyRegistration.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *
@@ -24,11 +24,7 @@ namespace React.AspNet
 		public void Register(TinyIoCContainer container)
 		{
 			container.Register<IFileSystem, AspNetFileSystem>().AsSingleton();
-#if NET451
-			container.Register<ICache, MemoryFileCache>().AsSingleton();
-#else
 			container.Register<ICache, MemoryFileCacheCore>().AsSingleton();
-#endif
 		}
 	}
 }

--- a/src/React.AspNet.Middleware/MemoryFileCacheCore.cs
+++ b/src/React.AspNet.Middleware/MemoryFileCacheCore.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2016-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -7,7 +7,6 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#if NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Caching.Memory;
@@ -89,4 +88,3 @@ namespace React.AspNet
 		}
 	}
 }
-#endif

--- a/src/React.AspNet.Middleware/React.AspNet.Middleware.csproj
+++ b/src/React.AspNet.Middleware/React.AspNet.Middleware.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright 2014-Present Facebook, Inc</Copyright>
     <AssemblyTitle>ReactJS.NET - Babel middleware for ASP.NET Core</AssemblyTitle>
     <Authors>Daniel Lo Nigro</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>React.AspNet.Middleware</AssemblyName>
     <AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
@@ -31,18 +31,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.1" />
-  </ItemGroup>
-
+  
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <NoWarn>7035</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/React.AspNet/React.AspNet.csproj
+++ b/src/React.AspNet/React.AspNet.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright 2014-Present Facebook, Inc</Copyright>
     <AssemblyTitle>ReactJS.NET (ASP.NET Core MVC)</AssemblyTitle>
     <Authors>Daniel Lo Nigro</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>React.AspNet</AssemblyName>
     <AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
@@ -31,11 +31,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <NoWarn>7035</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/React.Sample.Mvc6/Program.cs
+++ b/src/React.Sample.Mvc6/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *
@@ -7,12 +7,9 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+
 
 namespace React.Sample.Mvc6
 {
@@ -20,14 +17,12 @@ namespace React.Sample.Mvc6
 	{
 		public static void Main(string[] args)
 		{
-			var host = new WebHostBuilder()
-				.UseKestrel()
-				.UseContentRoot(Directory.GetCurrentDirectory())
-				.UseIISIntegration()
+			BuildWebHost(args).Run();
+		}
+
+		public static IWebHost BuildWebHost(string[] args) =>
+			WebHost.CreateDefaultBuilder(args)
 				.UseStartup<Startup>()
 				.Build();
-
-			host.Run();
-		}
 	}
 }

--- a/src/React.Sample.Mvc6/React.Sample.Mvc6.csproj
+++ b/src/React.Sample.Mvc6/React.Sample.Mvc6.csproj
@@ -23,7 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/React.Sample.Mvc6/React.Sample.Mvc6.csproj
+++ b/src/React.Sample.Mvc6/React.Sample.Mvc6.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>React.Sample.Mvc6</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>React.Sample.Mvc6</PackageId>
     <NoWarn>1701</NoWarn>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,26 +23,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.4.2" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="VroomJs" Version="1.2.3" />
   </ItemGroup>
 

--- a/src/React.Sample.Mvc6/Startup.cs
+++ b/src/React.Sample.Mvc6/Startup.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using React.AspNet;
+using System;
 
 namespace React.Sample.Mvc6
 {
@@ -32,7 +33,7 @@ namespace React.Sample.Mvc6
 		public IConfiguration Configuration { get; set; }
 
 		// This method gets called by the runtime.
-		public void ConfigureServices(IServiceCollection services)
+		public IServiceProvider ConfigureServices(IServiceCollection services)
 		{
 			// Add MVC services to the services container.
 			services.AddMvc();
@@ -41,6 +42,9 @@ namespace React.Sample.Mvc6
 
 			// Add ReactJS.NET services.
 			services.AddReact();
+
+			// Build the intermediate service provider then return it
+			return services.BuildServiceProvider();
 		}
 
 		// Configure is called after ConfigureServices is called.


### PR DESCRIPTION
- Support for ASP.NET Core targeting .NET Framework to 4.6.1
- The use of .NET Standard 2.0 means .NET Framework is no longer required for React.AspNet and React.AspNet.Middleware