### PR TITLE
Exclude node_modules

### DIFF
--- a/src/React.Core/React.Core.csproj
+++ b/src/React.Core/React.Core.csproj
@@ -20,6 +20,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="node_modules\**" />
+    <EmbeddedResource Remove="node_modules\**" />
+    <None Remove="node_modules\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs" />
     <Compile Include="..\SharedAssemblyVersionInfo.cs" />
     <EmbeddedResource Include="Resources\shims.js;Resources\react.generated.js;Resources\react.generated.min.js;Resources\babel.generated.min.js" />


### PR DESCRIPTION
This fixes building within VS 2017 community.
node_modules can sometimes contain paths that are very long, which can
trigger an msbuild bug

https://github.com/Microsoft/msbuild/issues/406