### PR TITLE
Resolve ASP.NET environments without HTTP contexts

### DIFF
--- a/src/React.Web/AspNetCache.cs
+++ b/src/React.Web/AspNetCache.cs
@@ -10,7 +10,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using System.Web.Caching;
 
 namespace React.Web
@@ -28,10 +27,10 @@ namespace React.Web
 		/// <summary>
 		/// Initializes a new instance of the <see cref="AspNetCache"/> class.
 		/// </summary>
-		/// <param name="context">The HTTP context</param>
-		public AspNetCache(HttpContextBase context)
+		/// <param name="cache">The Web application cache</param>
+		public AspNetCache(Cache cache)
 		{
-			_cache = context.Cache;
+			_cache = cache;
 		}
 
 		/// <summary>
@@ -62,8 +61,9 @@ namespace React.Web
 		/// will be cleared automatically
 		/// </param>
 		public void Set<T>(
-			string key, T data, 
-			TimeSpan slidingExpiration, 
+			string key,
+			T data,
+			TimeSpan slidingExpiration,
 			IEnumerable<string> cacheDependencyFiles = null
 		)
 		{

--- a/src/React.Web/AspNetFileSystem.cs
+++ b/src/React.Web/AspNetFileSystem.cs
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using System.Web;
+using System.Web.Hosting;
 
 namespace React.Web
 {
@@ -18,27 +18,13 @@ namespace React.Web
 	public class AspNetFileSystem : FileSystemBase
 	{
 		/// <summary>
-		/// The ASP.NET server utilities
-		/// </summary>
-		private readonly HttpServerUtilityBase _serverUtility;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="AspNetFileSystem"/> class.
-		/// </summary>
-		/// <param name="serverUtility">The server utility.</param>
-		public AspNetFileSystem(HttpServerUtilityBase serverUtility)
-		{
-			_serverUtility = serverUtility;
-		}
-
-		/// <summary>
 		/// Converts a path from an application relative path (~/...) to a full filesystem path
 		/// </summary>
 		/// <param name="relativePath">App-relative path of the file</param>
 		/// <returns>Full path of the file</returns>
 		public override string MapPath(string relativePath)
 		{
-			return _serverUtility.MapPath(relativePath);
+			return HostingEnvironment.MapPath(relativePath);
 		}
 	}
 }

--- a/src/React.Web/AssemblyRegistration.cs
+++ b/src/React.Web/AssemblyRegistration.cs
@@ -9,6 +9,7 @@
 
 using System.Diagnostics;
 using System.Web;
+using System.Web.Caching;
 using System.Web.Hosting;
 using React.TinyIoC;
 
@@ -47,7 +48,7 @@ namespace React.Web
 			}
 			else
 			{
-				container.Register<ICache, AspNetCache>().AsPerRequestSingleton();	
+				container.Register<ICache, AspNetCache>().AsPerRequestSingleton();
 			}
 
 			// Wrappers for built-in objects
@@ -55,6 +56,7 @@ namespace React.Web
 			container.Register<HttpServerUtilityBase>((c, o) => c.Resolve<HttpContextBase>().Server);
 			container.Register<HttpRequestBase>((c, o) => c.Resolve<HttpContextBase>().Request);
 			container.Register<HttpResponseBase>((c, o) => c.Resolve<HttpContextBase>().Response);
+			container.Register<Cache>((c, o) => HttpRuntime.Cache);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Sometimes, a user might wish to render HTML in an ASP.NET MVC web application outside of the context of a web request. An example would be email rendering in a separate thread. With the current implementations of `AspNetCache` and `AspNetFileSystem`, TinyIoC fails to inject the necessary objects because, internally, an `httpContext` is `null`.

For `AspNetCache`, we can obtain the cache from `HttpRuntime`, which `HttpContextBase` calls under the hood (as pointed out in the comments [here](http://www.hanselman.com/blog/UsingTheASPNETCacheOutsideOfASPNET.aspx)).

For `AspNetFileSystem`, `HttpServerUtilityBase` is used only for `.MapPath()`, which `HostingEnvironment` provides as a static method. This method [is slightly different](https://stackoverflow.com/questions/13441645/server-mappath-vs-request-mappath/18935501#18935501), but that should be a non-issue. For example, if the provided relative path is `null`, `React.Core` will throw sooner anyway.