### PR TITLE
Allowed Community, Enterprise, or Professional VS 2017 versions

### DIFF
--- a/dev-build.bat
+++ b/dev-build.bat
@@ -1,3 +1,19 @@
 @echo off
-"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" build.proj
+
+for %%s in (
+    "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
+    "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+    "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+) do (
+    if exist %%s (
+        echo %%s build.proj
+        %%s build.proj
+        goto :done
+    )
+)
+
+:notfound
+echo Could not find MSBuild.exe. Make sure Visual Studio 2017 is installed and try again.
+
+:done
 pause


### PR DESCRIPTION
Loops over the potential MSBuild.exe paths for all three, and runs with the first one. If one isn't found it complains.

Fixes #452.