### PR TITLE
Upgrade React.Router to ASP.NET Core 2.0

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -28,6 +28,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 		<PackageAssemblies Include="React.MSBuild" />
 		<PackageAssemblies Include="React.Owin" />
 		<PackageAssemblies Include="React.Router" />
+		<PackageAssemblies Include="React.Router.Mvc4" />
 		<PackageAssemblies Include="React.Web" />
 		<PackageAssemblies Include="React.Web.Mvc4" />
 		<PackageAssemblies Include="System.Web.Optimization.React" />

--- a/src/React.Router.Mvc4/React.Router.Mvc4.csproj
+++ b/src/React.Router.Mvc4/React.Router.Mvc4.csproj
@@ -8,7 +8,7 @@
 		<TargetFrameworks>net451</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AssemblyName>React.Router.Mvc4</AssemblyName>
-	  <DefineConstants>$(DefineConstants);LEGACYASPNET</DefineConstants>
+		<DefineConstants>$(DefineConstants);LEGACYASPNET</DefineConstants>
 		<AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <Compile Include="..\React.Router\*.cs" />
+		<Compile Include="..\React.Router\*.cs" />
 		<Compile Include="..\SharedAssemblyInfo.cs" />
 		<Compile Include="..\SharedAssemblyVersionInfo.cs" />
 		<Content Include="Content\**\*">

--- a/src/React.Router.Mvc4/React.Router.Mvc4.csproj
+++ b/src/React.Router.Mvc4/React.Router.Mvc4.csproj
@@ -5,13 +5,14 @@
 		<Copyright>Copyright 2014-Present Facebook, Inc</Copyright>
 		<AssemblyTitle>ReactJS.NET Router</AssemblyTitle>
 		<Authors>Daniel Lo Nigro, Gunnar Már Óttarsson</Authors>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net451</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>React.Router</AssemblyName>
+		<AssemblyName>React.Router.Mvc4</AssemblyName>
+	  <DefineConstants>$(DefineConstants);LEGACYASPNET</DefineConstants>
 		<AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-		<PackageId>React.Router</PackageId>
+		<PackageId>React.Router.Mvc4</PackageId>
 		<PackageTags>asp.net;mvc;asp;javascript;js;react;facebook;reactjs;babel;router;react router</PackageTags>
 		<PackageIconUrl>http://reactjs.net/img/logo_64.png</PackageIconUrl>
 		<PackageProjectUrl>http://reactjs.net/</PackageProjectUrl>
@@ -20,6 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+    <Compile Include="..\React.Router\*.cs" />
 		<Compile Include="..\SharedAssemblyInfo.cs" />
 		<Compile Include="..\SharedAssemblyVersionInfo.cs" />
 		<Content Include="Content\**\*">
@@ -29,8 +31,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
+		<Reference Include="System.Web" />
+		<Reference Include="Microsoft.CSharp" />
+		<PackageReference Include="Microsoft.AspNet.Mvc" Version="4.0.20710" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/React.Router/HtmlHelperExtensions.cs
+++ b/src/React.Router/HtmlHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -8,12 +8,9 @@
  */
 
 using System;
-using React.Exceptions;
-using React.TinyIoC;
 
-#if NET451
+#if LEGACYASPNET
 using System.Web;
-using System.Web.Mvc;
 using HttpResponse = System.Web.HttpResponseBase;
 using IHtmlHelper = System.Web.Mvc.HtmlHelper;
 #else

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -7,9 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-using JavaScriptEngineSwitcher.Core;
 using Newtonsoft.Json;
-using React.Exceptions;
 
 namespace React.Router
 {

--- a/src/React.Router/ReactRouterException.cs
+++ b/src/React.Router/ReactRouterException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Router
 	/// <summary>
 	/// React Router Exception
 	/// </summary>
-#if NET451
+#if LEGACYASPNET
 	[Serializable]
 #endif
 	public class ReactRouterException : Exception
@@ -38,7 +38,7 @@ namespace React.Router
 			: base(message, innerException) { }
 
 
-#if NET451
+#if LEGACYASPNET
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Router/SetServerResponse.cs
+++ b/src/React.Router/SetServerResponse.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#if NET451
+#if LEGACYASPNET
 using HttpResponse = System.Web.HttpResponseBase;
 #else
 using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
@@ -45,7 +45,7 @@ namespace React.Router
 				{
 					if (statusCode == 301)
 					{
-#if NET451
+#if LEGACYASPNET
 						Response.RedirectPermanent(context.url);
 #else
 						Response.Redirect(context.url, true);

--- a/src/React.sln
+++ b/src/React.sln
@@ -68,6 +68,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "React.AspNet.Middleware", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "React.Sample.CoreMvc", "React.Sample.CoreMvc\React.Sample.CoreMvc.csproj", "{305918EF-AD05-4743-9B3A-DB1CE84D467E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "React.Router.Mvc4", "React.Router.Mvc4\React.Router.Mvc4.csproj", "{2170D912-86E9-4CE3-8DA4-E1DE8D958E63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -142,6 +144,10 @@ Global
 		{305918EF-AD05-4743-9B3A-DB1CE84D467E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{305918EF-AD05-4743-9B3A-DB1CE84D467E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{305918EF-AD05-4743-9B3A-DB1CE84D467E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2170D912-86E9-4CE3-8DA4-E1DE8D958E63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2170D912-86E9-4CE3-8DA4-E1DE8D958E63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2170D912-86E9-4CE3-8DA4-E1DE8D958E63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2170D912-86E9-4CE3-8DA4-E1DE8D958E63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -164,6 +170,7 @@ Global
 		{D076273B-C5EA-47C7-923D-523E4C5EE30D} = {681C45FB-103C-48BC-B992-20C5B6B78F92}
 		{7E1C3999-1982-476D-9307-12B30737B41E} = {681C45FB-103C-48BC-B992-20C5B6B78F92}
 		{305918EF-AD05-4743-9B3A-DB1CE84D467E} = {A51CE5B6-294F-4D39-B32B-BF08DAF9B40B}
+		{2170D912-86E9-4CE3-8DA4-E1DE8D958E63} = {681C45FB-103C-48BC-B992-20C5B6B78F92}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DCF4A41E-C60D-4086-98A9-6F8508D7E8D0}

--- a/tests/React.Tests/React.Tests.csproj
+++ b/tests/React.Tests/React.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\React.Core\React.Core.csproj" />
     <ProjectReference Include="..\..\src\React.Owin\React.Owin.csproj" />
-    <ProjectReference Include="..\..\src\React.Router\React.Router.csproj" />
+    <ProjectReference Include="..\..\src\React.Router.Mvc4\React.Router.Mvc4.csproj" />
     <ProjectReference Include="..\..\src\React.Web.Mvc4\React.Web.Mvc4.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrades `React.Router` to ASP.NET 2.0.

Also splits ASP.NET MVC 4 support out into a separate `React.Router.Mvc4` project. This is required as you can use both ASP.NET Core and "classic" ASP.NET from .NET Framework, so simply discriminating based on framework version is not sufficient, and it actually needs to be two separate packages.

cc @dustinsoftware 