### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/React.Tests/Properties/AssemblyInfo.cs
+++ b/tests/React.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [assembly: AssemblyTitle("React.Tests.Core")]
 [assembly: AssemblyDescription("Unit tests for ReactJS.NET")]
 [assembly: ComVisible(false)]
 [assembly: Guid("30a20b1c-18fd-4c3c-a18d-44875dba0c73")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
This is caused by ConfigureMockEnvironment setting up the static
property Environment. Since tests run in parallel, there is a race
between which tests that set up different fake environments, causing
occasional failures. Disabling parallelization fixes the issue, and
tests run so fast that this should be ok.