### PR TITLE
Propose using weback export settings over expose-loader

### DIFF
--- a/site/jekyll/guides/webpack.md
+++ b/site/jekyll/guides/webpack.md
@@ -25,6 +25,16 @@ module.exports = {
 var Components = require('expose?Components!./components');
 ```
 
+An alternative to using expose-loader is to use the `library` property of the output configuration.
+``` javascript
+ output: {
+    path: path.join(__dirname, 'build'),
+    filename: '[name].bundle.js',
+    // This option sets the module of each entry point to a global variable with the same name
+    library: '[name]' 
+  },
+```
+
 The next step is to modify the `webpack.config.js` so that it creates a bundle from `Content/server.js`. A config similar to the following could work as a good starting point:
 
 ```javascript


### PR DESCRIPTION
I found it was a bit less boilerplate to expose components this way, rather than by using expose-loader.

Not 100% sure this is the best way to integrate into existing docs, but figured I'd offer it as a quick suggestion.  (Especially, might need some reworking to use with separate client/server bundles.)