### PR TITLE
Docs: Update expose-loader syntax for latest Webpack

### DIFF
--- a/site/jekyll/guides/webpack.md
+++ b/site/jekyll/guides/webpack.md
@@ -22,7 +22,7 @@ module.exports = {
 
 // All JavaScript in here will be loaded server-side
 // Expose components globally so ReactJS.NET can use them
-var Components = require('expose?Components!./components');
+var Components = require('expose-loader?Components!./components');
 ```
 
 The next step is to modify the `webpack.config.js` so that it creates a bundle from `Content/server.js`. A config similar to the following could work as a good starting point:


### PR DESCRIPTION
When using expose-loader with later versions of Webpack you need to keep -loader in the name like this:
`var Components = require('expose-loader?Components!./components'); `
instead of
`var Components = require('expose?Components!./components');`

This PR updates the docs with this change since most people needing this won't use Webpack 1.