### PR TITLE
Use NuGet reference for tutorial code

### DIFF
--- a/tutorial-code/tutorial-code.csproj
+++ b/tutorial-code/tutorial-code.csproj
@@ -16,16 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\React.AspNet\React.AspNet.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="React.AspNet" Version="3.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This was an oversight during the original .NET Core 2.0 port