### PR TITLE
Replace "path" with "location" for SSR + React Router.

### DIFF
--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -69,7 +69,7 @@ namespace React.Router
 		{
 			return string.Format(
 				@"React.createElement
-					({0}, Object.assign({1}, {{ path: '{2}', context: context }}))",
+					({0}, Object.assign({1}, {{ location: '{2}', context: context }}))",
 				ComponentName,
 				_serializedProps,
 				_path


### PR DESCRIPTION
According to the documentation, as well as my testing,
React Router expects the URL supplied to `StaticRouter`
to be provided via the `location` prop name.

React.NET currently supplies this value via the
`path` prop name.