### PR TITLE
Avoid large objects allocations and reuse everthing

### DIFF
--- a/src/React.AspNet/ActionHtmlString.cs
+++ b/src/React.AspNet/ActionHtmlString.cs
@@ -11,6 +11,7 @@ using System;
 using System.IO;
 
 #if LEGACYASPNET
+using System.Text;
 using System.Web;
 #else
 using System.Text.Encodings.Web;
@@ -40,13 +41,26 @@ namespace React.AspNet
 		}
 
 #if LEGACYASPNET
+		[ThreadStatic]
+		private static StringWriter _sharedStringWriter;
+
 		/// <summary>Returns an HTML-encoded string.</summary>
 		/// <returns>An HTML-encoded string.</returns>
 		public string ToHtmlString()
 		{
-			var sw = new StringWriter();
-			_textWriter(sw);
-			return sw.ToString();
+			var stringWriter = _sharedStringWriter;
+			if (stringWriter != null)
+			{
+				stringWriter.GetStringBuilder().Clear();
+			}
+			else
+			{
+				_sharedStringWriter = stringWriter = new StringWriter(new StringBuilder(128));
+			}
+
+			_textWriter(stringWriter);
+
+			return stringWriter.ToString();
 		}
 #else
 		/// <summary>

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -81,7 +81,7 @@ namespace React.AspNet
 						reactComponent.ContainerClass = containerClass;
 					}
 
-					writer.Write(reactComponent.RenderHtml(clientOnly, serverOnly, exceptionHandler));
+					reactComponent.RenderHtml(writer, clientOnly, serverOnly, exceptionHandler);
 				}
 				finally
 				{
@@ -131,9 +131,9 @@ namespace React.AspNet
 						reactComponent.ContainerClass = containerClass;
 					}
 
-					writer.Write(reactComponent.RenderHtml(clientOnly, exceptionHandler: exceptionHandler));
+					reactComponent.RenderHtml(writer, clientOnly, exceptionHandler: exceptionHandler);
 					writer.WriteLine();
-					WriteScriptTag(writer, bodyWriter => bodyWriter.Write(reactComponent.RenderJavaScript()));
+					WriteScriptTag(writer, bodyWriter => reactComponent.RenderJavaScript(bodyWriter));
 				}
 				finally
 				{
@@ -153,7 +153,7 @@ namespace React.AspNet
 			{
 				try
 				{
-					WriteScriptTag(writer, bodyWriter => bodyWriter.Write(Environment.GetInitJavaScript(clientOnly)));
+					WriteScriptTag(writer, bodyWriter => Environment.GetInitJavaScript(bodyWriter, clientOnly));
 				}
 				finally
 				{

--- a/src/React.Core/IReactComponent.cs
+++ b/src/React.Core/IReactComponent.cs
@@ -8,6 +8,7 @@
  */
 
 using System;
+using System.IO;
 
 namespace React
 {
@@ -63,5 +64,24 @@ namespace React
 		/// </summary>
 		/// <returns>JavaScript</returns>
 		string RenderJavaScript();
+
+		/// <summary>
+		/// Renders the HTML for this component. This will execute the component server-side and
+		/// return the rendered HTML.
+		/// </summary>
+		/// <param name="writer">The <see cref="T:System.IO.TextWriter" /> to which the content is written</param>
+		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
+		/// <param name="renderServerOnly">Only renders the common HTML mark up and not any React specific data attributes. Used for server-side only rendering.</param>
+		/// <param name="exceptionHandler">A custom exception handler that will be called if a component throws during a render. Args: (Exception ex, string componentName, string containerId)</param>
+		/// <returns>HTML</returns>
+		void RenderHtml(TextWriter writer, bool renderContainerOnly = false, bool renderServerOnly = false, Action<Exception, string, string> exceptionHandler = null);
+
+		/// <summary>
+		/// Renders the JavaScript required to initialise this component client-side. This will
+		/// initialise the React component, which includes attach event handlers to the
+		/// server-rendered HTML.
+		/// </summary>
+		/// <returns>JavaScript</returns>
+		void RenderJavaScript(TextWriter writer);
 	}
 }

--- a/src/React.Core/IReactEnvironment.cs
+++ b/src/React.Core/IReactEnvironment.cs
@@ -8,6 +8,8 @@
  */
 
 
+using System.IO;
+
 namespace React
 {
 	/// <summary>
@@ -114,5 +116,14 @@ namespace React
 		/// Gets the site-wide configuration.
 		/// </summary>
 		IReactSiteConfiguration Configuration { get; }
+
+		/// <summary>
+		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// attach event handlers to the server-rendered HTML.
+		/// </summary>
+		/// <param name="writer">The <see cref="T:System.IO.TextWriter" /> to which the content is written</param>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
+		/// <returns>JavaScript for all components</returns>
+		void GetInitJavaScript(TextWriter writer, bool clientOnly = false);
 	}
 }

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+using System.IO;
 using Newtonsoft.Json;
 
 namespace React.Router
@@ -67,15 +68,15 @@ namespace React.Router
 		/// Gets the JavaScript code to initialise the component
 		/// </summary>
 		/// <returns>JavaScript for component initialisation</returns>
-		protected override string GetComponentInitialiser()
+		protected override void WriteComponentInitialiser(TextWriter writer)
 		{
-			return string.Format(
-				@"React.createElement
-					({0}, Object.assign({1}, {{ location: '{2}', context: context }}))",
-				ComponentName,
-				_serializedProps,
-				_path
-			);
+			writer.Write("React.createElement(");
+			writer.Write(ComponentName);
+			writer.Write(", Object.assign(");
+			writer.Write(_serializedProps);
+			writer.Write(", { location: '");
+			writer.Write(_path);
+			writer.Write("', context: context }))");
 		}
 
 		/// <summary>
@@ -86,13 +87,13 @@ namespace React.Router
 		/// Client side React Router does not need context nor explicit path parameter.
 		/// </summary>
 		/// <returns>JavaScript</returns>
-		public override string RenderJavaScript()
+		public override void RenderJavaScript(TextWriter writer)
 		{
-			return string.Format(
-				"ReactDOM.hydrate({0}, document.getElementById({1}))",
-				base.GetComponentInitialiser(),
-				JsonConvert.SerializeObject(ContainerId, _configuration.JsonSerializerSettings) // SerializeObject accepts null settings
-			);
+			writer.Write("ReactDOM.hydrate(");
+			base.WriteComponentInitialiser(writer);
+			writer.Write(", document.getElementById(\"");
+			writer.Write(ContainerId);
+			writer.Write("\"))");
 		}
 	}
 }

--- a/tests/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
+++ b/tests/React.Tests/Mvc/HtmlHelperExtensionsTests.cs
@@ -8,6 +8,7 @@
  */
 
 using System;
+using System.IO;
 using System.Security.Cryptography;
 using Moq;
 using React.Web.Mvc;
@@ -34,8 +35,12 @@ namespace React.Tests.Mvc
 		public void ReactWithInitShouldReturnHtmlAndScript()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(false, false, null)).Returns("HTML");
-			component.Setup(x => x.RenderJavaScript()).Returns("JS");
+
+			component.Setup(x => x.RenderHtml(It.IsAny<TextWriter>(), false, false, null))
+				.Callback((TextWriter writer, bool renderContainerOnly, bool renderServerOnly, Action<Exception, string, string> exceptionHandler) => writer.Write("HTML")).Verifiable();
+
+			component.Setup(x => x.RenderJavaScript(It.IsAny<TextWriter>())).Callback((TextWriter writer) => writer.Write("JS")).Verifiable();
+
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
@@ -51,6 +56,7 @@ namespace React.Tests.Mvc
 				props: new { },
 				htmlTag: "span"
 			).ToHtmlString();
+
 			Assert.Equal(
 				"HTML" + System.Environment.NewLine + "<script>JS</script>",
 				result.ToString()
@@ -69,8 +75,10 @@ namespace React.Tests.Mvc
 			}
 
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(false, false, null)).Returns("HTML");
-			component.Setup(x => x.RenderJavaScript()).Returns("JS");
+			component.Setup(x => x.RenderHtml(It.IsAny<TextWriter>(), false, false, null))
+				.Callback((TextWriter writer, bool renderContainerOnly, bool renderServerOnly, Action<Exception, string, string> exceptionHandler) => writer.Write("HTML")).Verifiable();
+
+			component.Setup(x => x.RenderJavaScript(It.IsAny<TextWriter>())).Callback((TextWriter writer) => writer.Write("JS")).Verifiable();
 
 			var config = new Mock<IReactSiteConfiguration>();
 
@@ -92,6 +100,7 @@ namespace React.Tests.Mvc
 				props: new { },
 				htmlTag: "span"
 			).ToHtmlString();
+
 			Assert.Equal(
 				"HTML" + System.Environment.NewLine + "<script>JS</script>",
 				result.ToString()
@@ -106,6 +115,7 @@ namespace React.Tests.Mvc
 				props: new { },
 				htmlTag: "span"
 			).ToHtmlString();
+
 			Assert.Equal(
 				"HTML" + System.Environment.NewLine + "<script nonce=\"" + nonce + "\">JS</script>",
 				result.ToString()
@@ -116,7 +126,9 @@ namespace React.Tests.Mvc
 		public void EngineIsReturnedToPoolAfterRender()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(true, true, null)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(It.IsAny<TextWriter>(), false, false, null))
+				.Callback((TextWriter writer, bool renderContainerOnly, bool renderServerOnly, Action<Exception, string, string> exceptionHandler) => writer.Write("HTML")).Verifiable();
+
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
@@ -135,7 +147,8 @@ namespace React.Tests.Mvc
 				clientOnly: true,
 				serverOnly: false
 			).ToHtmlString();
-			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == false), null), Times.Once);
+
+			component.Verify(x => x.RenderHtml(It.IsAny<TextWriter>(), It.Is<bool>(y => y == true), It.Is<bool>(z => z == false), null), Times.Once);
 			environment.Verify(x => x.ReturnEngineToPool(), Times.Once);
 		}
 
@@ -143,7 +156,9 @@ namespace React.Tests.Mvc
 		public void ReactWithClientOnlyTrueShouldCallRenderHtmlWithTrue()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(true, true, null)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(It.IsAny<TextWriter>(), false, false, null))
+				.Callback((TextWriter writer, bool renderContainerOnly, bool renderServerOnly, Action<Exception, string, string> exceptionHandler) => writer.Write("HTML")).Verifiable();
+
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
@@ -161,14 +176,17 @@ namespace React.Tests.Mvc
 				clientOnly: true,
 				serverOnly: false
 			).ToHtmlString();
-			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == true), It.Is<bool>(z => z == false), null), Times.Once);
+
+			component.Verify(x => x.RenderHtml(It.IsAny<TextWriter>(), It.Is<bool>(y => y == true), It.Is<bool>(z => z == false), null), Times.Once);
 		}
 
 		[Fact]
 		public void ReactWithServerOnlyTrueShouldCallRenderHtmlWithTrue()
 		{
 			var component = new Mock<IReactComponent>();
-			component.Setup(x => x.RenderHtml(false, true, null)).Returns("HTML");
+			component.Setup(x => x.RenderHtml(It.IsAny<TextWriter>(), false, false, null))
+				.Callback((TextWriter writer, bool renderContainerOnly, bool renderServerOnly, Action<Exception, string, string> exceptionHandler) => writer.Write("HTML")).Verifiable();
+
 			var environment = ConfigureMockEnvironment();
 			environment.Setup(x => x.CreateComponent(
 				"ComponentName",
@@ -186,7 +204,8 @@ namespace React.Tests.Mvc
 				clientOnly: false,
 				serverOnly: true
 			).ToHtmlString();
-			component.Verify(x => x.RenderHtml(It.Is<bool>(y => y == false), It.Is<bool>(z => z == true), null), Times.Once);
+
+			component.Verify(x => x.RenderHtml(It.IsAny<TextWriter>(), It.Is<bool>(y => y == false), It.Is<bool>(z => z == true), null), Times.Once);
 		}
 	}
 }


### PR DESCRIPTION
Main part of this [PR](https://github.com/reactjs/React.NET/pull/522)
I propose to mark the old methods that do not take the TextWriter as obsolete, to avoid errors if it is overridden
@dustinsoftware @Daniel15 