### PR TITLE
Resolves Issue #521 Draft

### DIFF
--- a/src/React.AspNet/ActionHtmlString.cs
+++ b/src/React.AspNet/ActionHtmlString.cs
@@ -11,6 +11,7 @@ using System;
 using System.IO;
 
 #if LEGACYASPNET
+using System.Text;
 using System.Web;
 #else
 using System.Text.Encodings.Web;
@@ -40,13 +41,26 @@ namespace React.AspNet
 		}
 
 #if LEGACYASPNET
+		[ThreadStatic]
+		private static StringWriter _sharedStringWriter;
+
 		/// <summary>Returns an HTML-encoded string.</summary>
 		/// <returns>An HTML-encoded string.</returns>
 		public string ToHtmlString()
 		{
-			var sw = new StringWriter();
-			_textWriter(sw);
-			return sw.ToString();
+			var stringWriter = _sharedStringWriter;
+			if (stringWriter != null)
+			{
+				stringWriter.GetStringBuilder().Clear();
+			}
+			else
+			{
+				_sharedStringWriter = stringWriter = new StringWriter(new StringBuilder(128));
+			}
+
+			_textWriter(stringWriter);
+
+			return stringWriter.ToString();
 		}
 #else
 		/// <summary>

--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -81,7 +81,7 @@ namespace React.AspNet
 						reactComponent.ContainerClass = containerClass;
 					}
 
-					writer.Write(reactComponent.RenderHtml(clientOnly, serverOnly, exceptionHandler));
+					reactComponent.RenderHtml(writer, clientOnly, serverOnly, exceptionHandler);
 				}
 				finally
 				{
@@ -131,9 +131,9 @@ namespace React.AspNet
 						reactComponent.ContainerClass = containerClass;
 					}
 
-					writer.Write(reactComponent.RenderHtml(clientOnly, exceptionHandler: exceptionHandler));
+					reactComponent.RenderHtml(writer, clientOnly, exceptionHandler: exceptionHandler);
 					writer.WriteLine();
-					WriteScriptTag(writer, bodyWriter => bodyWriter.Write(reactComponent.RenderJavaScript()));
+					WriteScriptTag(writer, bodyWriter => reactComponent.RenderJavaScript(bodyWriter));
 				}
 				finally
 				{
@@ -153,7 +153,7 @@ namespace React.AspNet
 			{
 				try
 				{
-					WriteScriptTag(writer, bodyWriter => bodyWriter.Write(Environment.GetInitJavaScript(clientOnly)));
+					WriteScriptTag(writer, bodyWriter => Environment.GetInitJavaScript(bodyWriter, clientOnly));
 				}
 				finally
 				{

--- a/src/React.Core/IReactComponent.cs
+++ b/src/React.Core/IReactComponent.cs
@@ -8,6 +8,7 @@
  */
 
 using System;
+using System.IO;
 
 namespace React
 {
@@ -63,5 +64,24 @@ namespace React
 		/// </summary>
 		/// <returns>JavaScript</returns>
 		string RenderJavaScript();
+
+		/// <summary>
+		/// Renders the HTML for this component. This will execute the component server-side and
+		/// return the rendered HTML.
+		/// </summary>
+		/// <param name="writer">The <see cref="T:System.IO.TextWriter" /> to which the content is written</param>
+		/// <param name="renderContainerOnly">Only renders component container. Used for client-side only rendering.</param>
+		/// <param name="renderServerOnly">Only renders the common HTML mark up and not any React specific data attributes. Used for server-side only rendering.</param>
+		/// <param name="exceptionHandler">A custom exception handler that will be called if a component throws during a render. Args: (Exception ex, string componentName, string containerId)</param>
+		/// <returns>HTML</returns>
+		void RenderHtml(TextWriter writer, bool renderContainerOnly = false, bool renderServerOnly = false, Action<Exception, string, string> exceptionHandler = null);
+
+		/// <summary>
+		/// Renders the JavaScript required to initialise this component client-side. This will
+		/// initialise the React component, which includes attach event handlers to the
+		/// server-rendered HTML.
+		/// </summary>
+		/// <returns>JavaScript</returns>
+		void RenderJavaScript(TextWriter writer);
 	}
 }

--- a/src/React.Core/IReactEnvironment.cs
+++ b/src/React.Core/IReactEnvironment.cs
@@ -8,6 +8,8 @@
  */
 
 
+using System.IO;
+
 namespace React
 {
 	/// <summary>
@@ -114,5 +116,14 @@ namespace React
 		/// Gets the site-wide configuration.
 		/// </summary>
 		IReactSiteConfiguration Configuration { get; }
+
+		/// <summary>
+		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// attach event handlers to the server-rendered HTML.
+		/// </summary>
+		/// <param name="writer">The <see cref="T:System.IO.TextWriter" /> to which the content is written</param>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
+		/// <returns>JavaScript for all components</returns>
+		void GetInitJavaScript(TextWriter writer, bool clientOnly = false);
 	}
 }

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -233,7 +233,7 @@ namespace React
 		/// <returns>JavaScript</returns>
 		public virtual void RenderJavaScript(TextWriter writer)
 		{
-			writer.Write("ReactDOM.hydrate(");
+			ClientOnly ? writer.Write("ReactDOM.render(") : writer.Write("ReactDOM.hydrate(");
 			WriteComponentInitialiser(writer);
 			writer.Write(", document.getElementById(\"");
 			writer.Write(ContainerId);

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -105,7 +105,7 @@ namespace React
 		/// <param name="reactIdGenerator">React Id generator.</param>
 		/// <param name="componentName">Name of the component.</param>
 		/// <param name="containerId">The ID of the container DIV for this component</param>
-		public ReactComponent(IReactEnvironment environment, IReactSiteConfiguration configuration, IReactIdGenerator reactIdGenerator, string componentName, string containerId, boolean clientOnly)
+		public ReactComponent(IReactEnvironment environment, IReactSiteConfiguration configuration, IReactIdGenerator reactIdGenerator, string componentName, string containerId)
 		{
 			EnsureComponentNameValid(componentName);
 			_environment = environment;

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -95,6 +95,7 @@ namespace React
 					_configuration.JsonSerializerSettings);
 			}
 		}
+		public bool ClientOnly { get; set; }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ReactComponent"/> class.
@@ -104,7 +105,7 @@ namespace React
 		/// <param name="reactIdGenerator">React Id generator.</param>
 		/// <param name="componentName">Name of the component.</param>
 		/// <param name="containerId">The ID of the container DIV for this component</param>
-		public ReactComponent(IReactEnvironment environment, IReactSiteConfiguration configuration, IReactIdGenerator reactIdGenerator, string componentName, string containerId)
+		public ReactComponent(IReactEnvironment environment, IReactSiteConfiguration configuration, IReactIdGenerator reactIdGenerator, string componentName, string containerId, boolean clientOnly)
 		{
 			EnsureComponentNameValid(componentName);
 			_environment = environment;
@@ -233,7 +234,7 @@ namespace React
 		/// <returns>JavaScript</returns>
 		public virtual void RenderJavaScript(TextWriter writer)
 		{
-			ClientOnly ? writer.Write("ReactDOM.render(") : writer.Write("ReactDOM.hydrate(");
+			writer.Write(ClientOnly ? "ReactDOM.render(" : "ReactDOM.hydrate(");
 			WriteComponentInitialiser(writer);
 			writer.Write(", document.getElementById(\"");
 			writer.Write(ContainerId);

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -302,7 +302,7 @@ namespace React
 				EnsureUserScriptsLoaded();
 			}
 
-			var component = new ReactComponent(this, _config, _reactIdGenerator, clientOnly, componentName, containerId)
+			var component = new ReactComponent(this, _config, _reactIdGenerator, componentName, containerId)
 			{
 				ClientOnly = clientOnly,
 				Props = props,

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -22,7 +22,7 @@ using React.TinyIoC;
 namespace React
 {
 	/// <summary>
-	/// Request-specific ReactJS.NET environment. This is unique to the individual request and is 
+	/// Request-specific ReactJS.NET environment. This is unique to the individual request and is
 	/// not shared.
 	/// </summary>
 	public class ReactEnvironment : IReactEnvironment, IDisposable
@@ -70,7 +70,7 @@ namespace React
 		/// </summary>
 		protected readonly Lazy<string> _version = new Lazy<string>(GetVersion);
 		/// <summary>
-		/// Contains an engine acquired from a pool of engines. Only used if 
+		/// Contains an engine acquired from a pool of engines. Only used if
 		/// <see cref="IReactSiteConfiguration.ReuseJavaScriptEngines"/> is enabled.
 		/// </summary>
 		protected Lazy<PooledJsEngine> _engineFromPool;
@@ -141,7 +141,7 @@ namespace React
 			_fileSystem = fileSystem;
 			_fileCacheHash = fileCacheHash;
 			_reactIdGenerator = reactIdGenerator;
-			_babelTransformer = new Lazy<IBabel>(() => 
+			_babelTransformer = new Lazy<IBabel>(() =>
 				new Babel(this, _cache, _fileSystem, _fileCacheHash, _config)
 			);
 			_engineFromPool = new Lazy<PooledJsEngine>(() => _engineFactory.GetEngine());
@@ -302,8 +302,9 @@ namespace React
 				EnsureUserScriptsLoaded();
 			}
 
-			var component = new ReactComponent(this, _config, _reactIdGenerator, componentName, containerId)
+			var component = new ReactComponent(this, _config, _reactIdGenerator, clientOnly, componentName, containerId)
 			{
+				ClientOnly = clientOnly,
 				Props = props,
 				ServerOnly = serverOnly
 			};
@@ -329,7 +330,7 @@ namespace React
 		}
 
 		/// <summary>
-		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// Renders the JavaScript required to initialise all components client-side. This will
 		/// attach event handlers to the server-rendered HTML.
 		/// </summary>
 		/// <param name="clientOnly">True if server-side rendering will be bypassed. Defaults to false.</param>
@@ -344,7 +345,7 @@ namespace React
 		}
 
 		/// <summary>
-		/// Renders the JavaScript required to initialise all components client-side. This will 
+		/// Renders the JavaScript required to initialise all components client-side. This will
 		/// attach event handlers to the server-rendered HTML.
 		/// </summary>
 		/// <param name="writer">The <see cref="T:System.IO.TextWriter" /> to which the content is written</param>
@@ -371,12 +372,12 @@ namespace React
 
 		/// <summary>
 		/// Attempts to execute the provided JavaScript code using a non-pooled JavaScript engine (ie.
-		/// creates a new JS engine per-thread). This is because Babel uses a LOT of memory, so we 
+		/// creates a new JS engine per-thread). This is because Babel uses a LOT of memory, so we
 		/// should completely dispose any engines that have loaded Babel in order to conserve memory.
-		/// 
+		///
 		/// If an exception is thrown, retries the execution using a new thread (and hence a new engine)
 		/// with a larger maximum stack size.
-		/// This is required because JSXTransformer uses a huge stack which ends up being larger 
+		/// This is required because JSXTransformer uses a huge stack which ends up being larger
 		/// than what ASP.NET allows by default (256 KB).
 		/// </summary>
 		/// <typeparam name="T">Type to return from JavaScript call</typeparam>
@@ -396,7 +397,7 @@ namespace React
 
 			catch (Exception)
 			{
-				// Assume the exception MAY be an "out of stack space" error. Try running the code 
+				// Assume the exception MAY be an "out of stack space" error. Try running the code
 				// in a different thread with larger stack. If the same exception occurs, we know
 				// it wasn't a stack space issue.
 				T result = default(T);

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+using System.IO;
 using Newtonsoft.Json;
 
 namespace React.Router
@@ -67,15 +68,15 @@ namespace React.Router
 		/// Gets the JavaScript code to initialise the component
 		/// </summary>
 		/// <returns>JavaScript for component initialisation</returns>
-		protected override string GetComponentInitialiser()
+		protected override void WriteComponentInitialiser(TextWriter writer)
 		{
-			return string.Format(
-				@"React.createElement
-					({0}, Object.assign({1}, {{ location: '{2}', context: context }}))",
-				ComponentName,
-				_serializedProps,
-				_path
-			);
+			writer.Write("React.createElement(");
+			writer.Write(ComponentName);
+			writer.Write(", Object.assign(");
+			writer.Write(_serializedProps);
+			writer.Write(", { location: '");
+			writer.Write(_path);
+			writer.Write("', context: context }))");
 		}
 
 		/// <summary>
@@ -86,13 +87,13 @@ namespace React.Router
 		/// Client side React Router does not need context nor explicit path parameter.
 		/// </summary>
 		/// <returns>JavaScript</returns>
-		public override string RenderJavaScript()
+		public override void RenderJavaScript(TextWriter writer)
 		{
-			return string.Format(
-				"ReactDOM.hydrate({0}, document.getElementById({1}))",
-				base.GetComponentInitialiser(),
-				JsonConvert.SerializeObject(ContainerId, _configuration.JsonSerializerSettings) // SerializeObject accepts null settings
-			);
+			writer.Write("ReactDOM.hydrate(");
+			base.WriteComponentInitialiser(writer);
+			writer.Write(", document.getElementById(\"");
+			writer.Write(ContainerId);
+			writer.Write("\"))");
 		}
 	}
 }

--- a/tests/React.Tests/Core/ReactComponentTest.cs
+++ b/tests/React.Tests/Core/ReactComponentTest.cs
@@ -228,7 +228,7 @@ namespace React.Tests.Core
 			var result = component.RenderJavaScript();
 
 			Assert.Equal(
-				@"ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
+				@"ReactDOM.render(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
 				result
 			);
 		}

--- a/tests/React.Tests/Core/ReactComponentTest.cs
+++ b/tests/React.Tests/Core/ReactComponentTest.cs
@@ -213,6 +213,46 @@ namespace React.Tests.Core
 			);
 		}
 
+		[Fact]
+		public void RenderJavaScriptShouldCallRenderComponentWithReactDOMRender()
+		{
+			var environment = new Mock<IReactEnvironment>();
+			var clientOnly = true;
+			var config = new Mock<IReactSiteConfiguration>();
+			var reactIdGenerator = new Mock<IReactIdGenerator>();
+
+			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, clientOnly, "Foo", "container")
+			{
+				Props = new { hello = "World" }
+			};
+			var result = component.RenderJavaScript();
+
+			Assert.Equal(
+				@"ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
+				result
+			);
+		}
+
+		[Fact]
+		public void RenderJavaScriptShouldCallRenderComponentwithReactDOMHydrate()
+		{
+			var environment = new Mock<IReactEnvironment>();
+			var clientOnly = false;
+			var config = new Mock<IReactSiteConfiguration>();
+			var reactIdGenerator = new Mock<IReactIdGenerator>();
+
+			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, clientOnly, "Foo", "container")
+			{
+				Props = new { hello = "World" }
+			};
+			var result = component.RenderJavaScript();
+
+			Assert.Equal(
+				@"ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
+				result
+			);
+		}
+
 		[Theory]
 		[InlineData("Foo", true)]
 		[InlineData("Foo.Bar", true)]
@@ -284,7 +324,7 @@ namespace React.Tests.Core
 			Action<Exception, string, string> customHandler = (ex, name, id) => customHandlerInvoked = true;
 			component.RenderHtml(exceptionHandler: customHandler);
 			Assert.True(customHandlerInvoked);
-			
+
 			// Custom exception handler set
 			Exception caughtException = null;
 			config.Setup(x => x.ExceptionHandler).Returns((ex, name, id) => caughtException = ex);

--- a/tests/React.Tests/Core/ReactComponentTest.cs
+++ b/tests/React.Tests/Core/ReactComponentTest.cs
@@ -217,13 +217,12 @@ namespace React.Tests.Core
 		public void RenderJavaScriptShouldCallRenderComponentWithReactDOMRender()
 		{
 			var environment = new Mock<IReactEnvironment>();
-			var clientOnly = true;
 			var config = new Mock<IReactSiteConfiguration>();
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
 			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container")
 			{
-				ClientOnly = true;
+				ClientOnly = true,
 				Props = new { hello = "World" }
 			};
 			var result = component.RenderJavaScript();
@@ -238,13 +237,12 @@ namespace React.Tests.Core
 		public void RenderJavaScriptShouldCallRenderComponentwithReactDOMHydrate()
 		{
 			var environment = new Mock<IReactEnvironment>();
-			var clientOnly = false;
 			var config = new Mock<IReactSiteConfiguration>();
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
 			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container")
 			{
-				ClientOnly = false;
+				ClientOnly = false,
 				Props = new { hello = "World" }
 			};
 			var result = component.RenderJavaScript();

--- a/tests/React.Tests/Core/ReactComponentTest.cs
+++ b/tests/React.Tests/Core/ReactComponentTest.cs
@@ -221,8 +221,9 @@ namespace React.Tests.Core
 			var config = new Mock<IReactSiteConfiguration>();
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
-			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, clientOnly, "Foo", "container")
+			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container")
 			{
+				ClientOnly = true;
 				Props = new { hello = "World" }
 			};
 			var result = component.RenderJavaScript();
@@ -241,8 +242,9 @@ namespace React.Tests.Core
 			var config = new Mock<IReactSiteConfiguration>();
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
-			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, clientOnly, "Foo", "container")
+			var component = new ReactComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container")
 			{
+				ClientOnly = false;
 				Props = new { hello = "World" }
 			};
 			var result = component.RenderJavaScript();


### PR DESCRIPTION
Hi, I wanted to submit my first open source PR for issue #521 for some review!

> Add ClientOnly as a property to ReactComponent. When ReactEnvironment.CreateComponent is called, ClientOnly needs to be set.

I believe I set this correctly in ReactEnvironment.cs on lines 305 and 307.  Since this is a new parameter for ReactComponent, do I need to go in and add the ClientOnly parameter to every call of ReactComponent?  Or should I set a default value?

> When RenderJavaScript is called in ReactComponent, ClientOnly should be checked. If true, ReactDOM.render should be written to the script instead of ReactDOM.hydrate.

I used a ternary operator for the conditional in ReactComponent.cs on line 236.  I saw ternary operators used in other parts of the codebase, is it appropriate to use here?  Also, am I correctly referencing the ClientOnly property from the ReactComponent?

> Let's make sure to add a unit test for this as well.

I added two unit tests, one for each case.