### PR TITLE
Updated the MVC tutorial for React 16

### DIFF
--- a/site/jekyll/getting-started/tutorial_aspnet4.md
+++ b/site/jekyll/getting-started/tutorial_aspnet4.md
@@ -94,7 +94,7 @@ React is all about modular, composable components. For our comment box example, 
   - CommentForm
 ```
 
-Let's build the `CommentBox` component, which is just displays a simple `<div>`. Add this code to `Tutorial.jsx`:
+Let's build the `CommentBox` component, which just displays a simple `<div>`. Add this code to `Tutorial.jsx`:
 
 ```javascript
 class CommentBox extends React.Component {
@@ -146,7 +146,7 @@ Its use is optional but we've found JSX syntax easier to use than plain JavaScri
 
 #### What's going on
 
-We are defining a new JavaScript class that extends from the React.Component class. In our class, we will define some properties and some methods to build from what React.Component already gives us. The most important of our methods is called `render` which returns a tree of React components that will eventually render to HTML.
+We are defining a new JavaScript class that extends from the React.Component class. In our class, we will define some properties and some methods to build from what React.Component already gives us. The most important of these methods is called `render` which returns a tree of React components that will eventually render to HTML.
 
 The `<div>` tags are not actual DOM nodes; they are instantiations of React `div` components. You can think of these as markers or pieces of data that React knows how to handle. React is **safe**. We are not generating HTML strings so XSS protection is the default.
 
@@ -472,7 +472,7 @@ This component is different from the prior components because it will have to re
 
 ### Reactive state
 
-So far, based on its props, each component has rendered itself once. `props` are immutable: they are passed from the parent and are "owned" by the parent. To implement interactions, we introduce a mutable **state** to the component. `this.state` is private to the component and can be changed by calling `this.setState()` and passing an object that represents changes in state. When the state updates, the component re-renders itself.
+So far, based on its props, each component has rendered itself once. `props` are immutable: they are passed from the parent and are "owned" by the parent. To implement interactions, we introduce mutable **state** to the component. `this.state` is private to the component and can be changed by calling `this.setState()` and passing an object that represents changes in state. When the state updates, the component re-renders itself.
 
 `render()` methods are written declaratively as functions of `this.props` and `this.state`. The framework guarantees the UI is always consistent with the inputs.
 
@@ -617,16 +617,16 @@ class CommentForm extends React.Component {
 
 #### Controlled components
 
-With the traditional DOM, `input` elements are rendered and the browser manages their state (its rendered value). As a result, the state of the actual DOM will differ from that of the component. This is not ideal as the state of the view will differ from that of the component. In React, components should always represent the state of the view and not only at the point of initialization.
+With the traditional DOM, `input` elements are rendered and the browser manages the state (its rendered value). As a result, the state of the actual DOM will differ from that of the component. This is not ideal as the state of the view will differ from that of the component. In React, components should always represent the state of the view and not only at the point of initialization.
 
 Hence, we will be using `this.state` to save the user's input as it is entered. We define an initial `state` with two properties `author` and `text` and set them to be empty strings. In our `<input>` elements, we set the `value` prop to reflect the `state` of the component and attach `onChange` handlers to them. These `<input>` elements with a `value` set are called controlled components. Read more about controlled components on the [Forms article](https://reactjs.org/docs/forms.html#controlled-components).
 
 ```javascript{2-13,16-28}
 class CommentForm extends React.Component {
   constructor(props) {
-	  super(props);
+    super(props);
     this.state = {author: '', text: ''};
-		this.handleAuthorChange = this.handleAuthorChange.bind(this);
+    this.handleAuthorChange = this.handleAuthorChange.bind(this);
     this.handleTextChange = this.handleTextChange.bind(this);
   }
   handleAuthorChange(e) {
@@ -670,11 +670,11 @@ Let's make the form interactive. When the user submits the form, we should clear
 ```javascript{7,15-24,27}
 class CommentForm extends React.Component {
   constructor(props) {
-	  super(props);
+    super(props);
     this.state = {author: '', text: ''};
-		this.handleAuthorChange = this.handleAuthorChange.bind(this);
+    this.handleAuthorChange = this.handleAuthorChange.bind(this);
     this.handleTextChange = this.handleTextChange.bind(this);
-		this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
   handleAuthorChange(e) {
     this.setState({author: e.target.value});
@@ -682,7 +682,7 @@ class CommentForm extends React.Component {
   handleTextChange(e) {
     this.setState({text: e.target.value});
   }
-	handleSubmit(e) {
+  handleSubmit(e) {
     e.preventDefault();
     const author = this.state.author.trim();
     const text = this.state.text.trim();
@@ -720,14 +720,14 @@ We attach an `onSubmit` handler to the form that clears the form fields when the
 
 When a user submits a comment, we will need to refresh the list of comments to include the new one. It makes sense to do all of this logic in `CommentBox` since `CommentBox` owns the state that represents the list of comments.
 
-We need to pass data from the child component back up to its parent. We do this in our parent's `render` method by passing a new callback (`handleCommentSubmit`) into the child and binding it to the child's `onCommentSubmit` event. Whenever the event is triggered, the callback will be invoked:
+We need to pass data from the child component back up to its parent. We do this in our parent's `render` method by passing a new callback (`handleCommentSubmit`) into the child, binding it to the child's `onCommentSubmit` event. Whenever the event is triggered, the callback will be invoked:
 
 ```javascript{5,16-18,28}
 class CommentBox extends React.Component {
   constructor(props) {
     super(props);
     this.state = { data: [] };
-		this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
+    this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
   }
   loadCommentsFromServer() {
     const xhr = new XMLHttpRequest();
@@ -738,7 +738,7 @@ class CommentBox extends React.Component {
     };
     xhr.send();
   }
-	handleCommentSubmit(comment) {
+  handleCommentSubmit(comment) {
     // TODO: submit to the server and refresh the list
   }
   componentDidMount() {
@@ -762,11 +762,11 @@ Now that `CommentBox` has made the callback available to `CommentForm` via the `
 ```javascript{22}
 class CommentForm extends React.Component {
   constructor(props) {
-	  super(props);
+    super(props);
     this.state = {author: '', text: ''};
-		this.handleAuthorChange = this.handleAuthorChange.bind(this);
+    this.handleAuthorChange = this.handleAuthorChange.bind(this);
     this.handleTextChange = this.handleTextChange.bind(this);
-		this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
   handleAuthorChange(e) {
     this.setState({author: e.target.value});
@@ -774,7 +774,7 @@ class CommentForm extends React.Component {
   handleTextChange(e) {
     this.setState({text: e.target.value});
   }
-	handleSubmit(e) {
+  handleSubmit(e) {
     e.preventDefault();
     const author = this.state.author.trim();
     const text = this.state.text.trim();
@@ -813,7 +813,7 @@ class CommentBox extends React.Component {
   constructor(props) {
     super(props);
     this.state = { data: [] };
-		this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
+    this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
   }
   loadCommentsFromServer() {
     const xhr = new XMLHttpRequest();
@@ -824,7 +824,7 @@ class CommentBox extends React.Component {
     };
     xhr.send();
   }
-	handleCommentSubmit(comment) {
+  handleCommentSubmit(comment) {
     const data = new FormData();
     data.append('Author', comment.Author);
     data.append('Text', comment.Text);
@@ -1104,14 +1104,14 @@ namespace ReactDemo
 		public static void Configure()
 		{
 			ReactSiteConfiguration.Configuration
-				.AddScript("~/Scripts/remarkable.min.js")
+				.AddScript("~/js/remarkable.min.js")
 				.AddScript("~/Scripts/Tutorial.jsx");
 		}
 	}
 }
 ```
 
-Note that we need a copy of Remarkable in order to load it for server-side rendering. In a production app you'd probably use Bower or npm for this, but for our tutorial you can just [download the file from CDNJS](https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js) and save it into `~/Scripts`.
+Note that we need a copy of Remarkable in order to load it for server-side rendering. In a production app you'd probably use Bower or npm for this, but for our tutorial you can just [download the file from CDNJS](https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js) and save it into `~/js`.
 
 That's it! Now if you build and refresh your application, you should notice that the comments box is rendered immediately rather than having a slight delay. If you view the source of the page, you will see the initial comments directly in the HTML itself:
 

--- a/site/jekyll/getting-started/tutorial_aspnet4.md
+++ b/site/jekyll/getting-started/tutorial_aspnet4.md
@@ -8,9 +8,9 @@ layout: docs
 >
 > This tutorial is for Visual Studio 2013 and ASP.NET MVC 4. If you like, you can [see the tutorial for ASP.NET Core instead](/getting-started/tutorial.html)
 
-This tutorial covers the end-to-end process of creating a brand new ASP.NET MVC website and adding a React component in it. We will start from scratch and end with a fully functioning component. It assumes you have basic knowledge of ASP.NET MVC and using Visual Studio. This tutorial is based off the [original React tutorial](http://facebook.github.io/react/docs/tutorial.html) but has been modified specifically for ReactJS.NET.
+This tutorial covers the end-to-end process of creating a brand new ASP.NET MVC website and adding a React component in it. We will start from scratch and end with a fully functioning component. It assumes you have basic knowledge of ASP.NET MVC and using Visual Studio. This tutorial is based off the [original React tutorial](https://reactjs.org/tutorial/tutorial.html) but has been modified specifically for ReactJS.NET.
 
-We'll be building a simple, but realistic comments box that you can drop into a blog, a basic version of the realtime comments offered by Disqus, LiveFyre or Facebook comments.
+We'll be building a simple, but realistic, comments box that you can drop into a blog. It's a basic version of the realtime comments offered by Disqus, LiveFyre or Facebook comments.
 
 We'll provide:
 
@@ -20,33 +20,34 @@ We'll provide:
 
 It'll also have a few neat features:
 
-* **Optimistic commenting:** comments appear in the list before they're saved on the server so it feels fast.
+* **Optimistic updates:** comments appear in the list before they're saved on the server so it feels fast.
 * **Live updates:** other users' comments are popped into the comment view in real time.
 * **Markdown formatting:** users can use Markdown to format their text.
 
 ## Getting started
 
-For this tutorial we'll be using Visual Studio 2013, although any version of Visual Studio from 2010 onwards is fine, including [Visual Studio Express 2013](http://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx) which is completely free. We will be using ASP.NET MVC 4, although similar steps apply for ASP.NET MVC 5.
+For this tutorial we'll be using Visual Studio 2013, although any version of Visual Studio from 2010 onwards is fine, including [Visual Studio Express](https://www.visualstudio.com/vs/express/) which is completely free. We will be using ASP.NET MVC 4, although similar steps apply for ASP.NET MVC 5.
 
 ### New Project
 
 Start by creating a new ASP.NET MVC 4 project:
 
-1. File → New &rarr; Project
-2. Select ".NET Framework 4" and Templates → Visual C# → Web → ASP.NET MVC 4 Web Application. Call it "ReactDemo"
+1. File → New → Project
+1. Select ".NET Framework 4" and Templates → Visual C# → Web → ASP.NET MVC 4 Web Application.
+1. Call it "ReactDemo"
    <img src="/img/tutorial/newproject.png" alt="Screenshot: New Project" width="650" />
-3. In the "New ASP.NET MVC 4 Project" dialog, select the Empty template. I always recommend using this template for new sites, as the others include a large amount of third-party packages that you may not even use.
+1. In the "New ASP.NET MVC 4 Project" dialog, select the Empty template. I always recommend using this template for new sites, as the others include a large number of third-party packages that you may not even use.
    <img src="/img/tutorial/basicmvc.png" alt="Screenshot: New ASP.NET MVC 4 Project dialog" width="500" />
 
 ### Install ReactJS.NET
 
-We need to install ReactJS.NET to the newly-created project. This is accomplished using NuGet, a package manager for .NET. Right-click on the "ReactDemo" project in the Solution Explorer and select "Manage NuGet Packages". Search for "ReactJS.NET" and install the **ReactJS.NET (MVC 4 and 5)** package.
+We need to install ReactJS.NET to the newly-created project. This is accomplished using NuGet, a package manager for .NET. Right-click on the "ReactDemo" project in the Solution Explorer and select "Manage NuGet Packages". Search for "ReactJS.NET" and install the **React.Web.Mvc4** package.
 
 <img src="/img/tutorial/nuget.png" alt="Screenshot: Install NuGet Packages" width="650" />
 
 ### Create basic controller and view
 
-Since this tutorial focuses mainly on ReactJS.NET itself, we will not cover creation of an MVC controller in much detail. To learn more about ASP.NET MVC, refer to [its official website](http://www.asp.net/mvc).
+Since this tutorial focuses mainly on ReactJS.NET itself, we will not cover creation of an MVC controller in much detail. To learn more about ASP.NET MVC, refer to [its official website](https://www.asp.net/mvc).
 
 Right-click on the Controllers folder and click Add → Controller. Name the controller "HomeController" and select "Empty MVC Controller" as the template. Once the controller has been created, right-click on `return View()` and click "Add View". Enter the following details:
 
@@ -62,18 +63,18 @@ Replace the contents of the new view file with the following:
 
 ```html
 @{
-    Layout = null;
+  Layout = null;
 }
 <html>
 <head>
-	<title>Hello React</title>
+  <title>Hello React</title>
 </head>
 <body>
-	<div id="content"></div>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js"></script>
-	<script src="@Url.Content("~/Scripts/Tutorial.jsx")"></script>
+  <div id="content"></div>
+  <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js"></script>
+  <script src="@Url.Content("~/Scripts/Tutorial.jsx")"></script>
 </body>
 </html>
 ```
@@ -93,18 +94,19 @@ React is all about modular, composable components. For our comment box example, 
   - CommentForm
 ```
 
-Let's build the `CommentBox` component, which is just a simple `<div>`. Add this code to `Tutorial.jsx`:
+Let's build the `CommentBox` component, which is just displays a simple `<div>`. Add this code to `Tutorial.jsx`:
 
 ```javascript
-var CommentBox = React.createClass({
-  render: function() {
+class CommentBox extends React.Component {
+  render() {
     return (
       <div className="commentBox">
         Hello, world! I am a CommentBox.
       </div>
     );
   }
-});
+}
+
 ReactDOM.render(
   <CommentBox />,
   document.getElementById('content')
@@ -133,17 +135,18 @@ var CommentBox = React.createClass({displayName: 'CommentBox',
     );
   }
 });
+
 ReactDOM.render(
   React.createElement(CommentBox, null),
   document.getElementById('content')
 );
 ```
 
-Its use is optional but we've found JSX syntax easier to use than plain JavaScript. Read more on the [JSX Syntax article](http://facebook.github.io/react/docs/jsx-in-depth.html).
+Its use is optional but we've found JSX syntax easier to use than plain JavaScript. Read more in React's ["JSX In Depth"](https://reactjs.org/docs/jsx-in-depth.html) article.
 
 #### What's going on
 
-We pass some methods in a JavaScript object to `React.createClass()` to create a new React component. The most important of these methods is called `render` which returns a tree of React components that will eventually render to HTML.
+We are defining a new JavaScript class that extends from the React.Component class. In our class, we will define some properties and some methods to build from what React.Component already gives us. The most important of our methods is called `render` which returns a tree of React components that will eventually render to HTML.
 
 The `<div>` tags are not actual DOM nodes; they are instantiations of React `div` components. You can think of these as markers or pieces of data that React knows how to handle. React is **safe**. We are not generating HTML strings so XSS protection is the default.
 
@@ -151,38 +154,39 @@ You do not have to return basic HTML. You can return a tree of components that y
 
 `ReactDOM.render()` instantiates the root component, starts the framework, and injects the markup into a raw DOM element, provided as the second argument.
 
-The `ReactDOM` module exposes DOM-specific methods, while `React` has the core tools shared by React on different platforms (e.g., [React Native](http://facebook.github.io/react-native/)).
+The `ReactDOM` module exposes DOM-specific methods, while `React` has the core tools shared by React on different platforms (e.g., [React Native](https://facebook.github.io/react-native/)).
+
 ## Composing components
 
 Let's build skeletons for `CommentList` and `CommentForm` which will, again, be simple `<div>`s. Add these two components to your file, keeping the existing `CommentBox` declaration and `ReactDOM.render` call:
 
 ```javascript
-var CommentList = React.createClass({
-  render: function() {
+class CommentList extends React.Component {
+  render() {
     return (
       <div className="commentList">
         Hello, world! I am a CommentList.
       </div>
     );
   }
-});
+}
 
-var CommentForm = React.createClass({
-  render: function() {
+class CommentForm extends React.Component {
+  render() {
     return (
       <div className="commentForm">
         Hello, world! I am a CommentForm.
       </div>
     );
   }
-});
+}
 ```
 
 Next, update the `CommentBox` component to use these new components:
 
 ```javascript{5-7}
-var CommentBox = React.createClass({
-  render: function() {
+class CommentBox extends React.Component {
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -191,18 +195,18 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
-Notice how we're mixing HTML tags and components we've built. HTML components are regular React components, just like the ones you define, with one difference. The JSX compiler will automatically rewrite HTML tags to `React.createElement(tagName)` expressions and leave everything else alone. This is to prevent the pollution of the global namespace.
+Notice how we're mixing HTML tags and components we've built. HTML tags are React components just like the ones you define, but they have one difference. The JSX compiler will automatically rewrite HTML tags to `React.createElement(tagName)` expressions and leave everything else alone. This is to prevent the pollution of the global namespace.
 
 ### Using props
 
 Let's create the `Comment` component, which will depend on data passed in from our `CommentList` component. Data passed in from the `CommentList` component is available as a 'property' on our `Comment` component. These 'properties' are accessed through `this.props`. Using props, we will be able to read the data passed to the `Comment` from the `CommentList`, and render some markup:
 
 ```javascript
-var Comment = React.createClass({
-  render: function() {
+class Comment extends React.Component {
+  render() {
     return (
       <div className="comment">
         <h2 className="commentAuthor">
@@ -212,18 +216,18 @@ var Comment = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
-By surrounding a JavaScript expression in braces inside JSX (as either an attribute or child), you can drop text or React components into the tree. We access named attributes passed to the component as keys on `this.props` and any nested elements as `this.props.children`.
+By surrounding a JavaScript expression with braces inside JSX (as either an attribute or child), you can drop text or React components into the tree. We access named attributes passed to the component as keys on `this.props` and any nested elements as `this.props.children`.
 
 ### Component Properties
 
 Now that we have defined the `Comment` component, we will want to pass it the author name and comment text. This allows us to reuse the same code for each unique comment. Now let's add some comments within our `CommentList`:
 
 ```javascript{5-7}
-var CommentList = React.createClass({
-  render: function() {
+class CommentList extends React.Component {
+  render() {
     return (
       <div className="commentList">
         <Comment author="Daniel Lo Nigro">Hello ReactJS.NET World!</Comment>
@@ -232,7 +236,7 @@ var CommentList = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
 Note that we have passed some data from the parent `CommentList` component to the child `Comment` components. For example, we passed *Daniel Lo Nigro* (via the `author` attribute) and *Hello ReactJS.NET World* (via an XML-like child node) to the first `Comment`. As noted above, the `Comment` component will access these 'properties' through `this.props.author`, and `this.props.children`.
@@ -241,12 +245,12 @@ Note that we have passed some data from the parent `CommentList` component to th
 
 Markdown is a simple way to format your text inline. For example, surrounding text with asterisks will make it emphasized.
 
-In this tutorial we use a third-party library **remarkable** which takes Markdown text and converts it to raw HTML. We already included this library with the original markup for the page, so we can just start using it. Let's convert the comment text to Markdown and output it:
+In this tutorial we use a third-party library called [remarkable](https://github.com/jonschlinkert/remarkable) which takes Markdown text and converts it to raw HTML. We already included this library with the original markup for the page, so we can just start using it. Let's convert the comment text to Markdown and output it:
 
 ```javascript{3,9}
-var Comment = React.createClass({
-  render: function() {
-    var md = new Remarkable();
+class Comment extends React.Component {
+  render() {
+    const md = new Remarkable();
     return (
       <div className="comment">
         <h2 className="commentAuthor">
@@ -256,7 +260,7 @@ var Comment = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
 All we're doing here is calling the remarkable library. We need to convert `this.props.children` from React's wrapped text to a raw string that remarkable will understand so we explicitly call `toString()`.
@@ -265,15 +269,14 @@ But there's a problem! Our rendered comments look like this in the browser: "`<p
 
 That's React protecting you from an [XSS attack](https://en.wikipedia.org/wiki/Cross-site_scripting). There's a way to get around it but the framework warns you not to use it:
 
-```javascript{2-6,14}
-var Comment = React.createClass({
-  rawMarkup: function() {
-    var md = new Remarkable();
-    var rawMarkup = md.render(this.props.children.toString());
+```javascript{2-6,13}
+class Comment extends React.Component {
+  rawMarkup() {
+    const md = new Remarkable();
+    const rawMarkup = md.render(this.props.children.toString());
     return { __html: rawMarkup };
-  },
-
-  render: function() {
+  }
+  render() {
     return (
       <div className="comment">
         <h2 className="commentAuthor">
@@ -283,7 +286,7 @@ var Comment = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
 This is a special API that intentionally makes it difficult to insert raw HTML, but for remarkable we'll take advantage of this backdoor.
@@ -295,7 +298,7 @@ This is a special API that intentionally makes it difficult to insert raw HTML, 
 So far we've been inserting the comments directly in the source code. Instead, let's render a blob of JSON data into the comment list. Eventually this will come from the server, but for now, write it in your source:
 
 ```javascript
-var data = [
+const data = [
   { Id: 1, Author: "Daniel Lo Nigro", Text: "Hello ReactJS.NET World!" },
   { Id: 2, Author: "Pete Hunt", Text: "This is one comment" },
   { Id: 3, Author: "Jordan Walke", Text: "This is *another* comment" }
@@ -305,8 +308,8 @@ var data = [
 We need to get this data into `CommentList` in a modular way. Modify `CommentBox` and the `ReactDOM.render()` call to pass this data into the `CommentList` via props:
 
 ```javascript{6,14}
-var CommentBox = React.createClass({
-  render: function() {
+class CommentBox extends React.Component {
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -315,7 +318,7 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(
   <CommentBox data={data} />,
@@ -325,23 +328,21 @@ ReactDOM.render(
 
 Now that the data is available in the `CommentList`, let's render the comments dynamically:
 
-```javascript{3-9,12}
-var CommentList = React.createClass({
-  render: function() {
-    var commentNodes = this.props.data.map(function(comment) {
-      return (
-        <Comment author={comment.Author} key={comment.Id}>
-          {comment.Text}
-        </Comment>
-      );
-    });
+```javascript{3-7,10}
+class CommentList extends React.Component {
+  render() {
+    const commentNodes = this.props.data.map(comment => (
+      <Comment author={comment.Author} key={comment.Id}>
+        {comment.Text}
+      </Comment>
+    ));
     return (
       <div className="commentList">
         {commentNodes}
       </div>
     );
   }
-});
+}
 ```
 
 That's it!
@@ -465,24 +466,25 @@ ReactDOM.render(
 );
 ```
 
-Note that in a real app, you should generate the URL server-side (via `Url.Action` call) and pass it down, or use [RouteJs](http://dan.cx/projects/routejs) rather than hard-coding it. This tutorial hard-codes it for simplicity.
+Note that in a real app, you should generate the URL server-side (via `Url.Action` call) and pass it down, or use [RouteJs](https://github.com/Daniel15/RouteJs) rather than hard-coding it. This tutorial hard-codes it for simplicity.
 
 This component is different from the prior components because it will have to re-render itself. The component won't have any data until the request from the server comes back, at which point the component may need to render some new comments.
 
 ### Reactive state
 
-So far, based on its props, each component has rendered itself once. `props` are immutable: they are passed from the parent and are "owned" by the parent. To implement interactions, we introduce mutable **state** to the component. `this.state` is private to the component and can be changed by calling `this.setState()`. When the state updates, the component re-renders itself.
+So far, based on its props, each component has rendered itself once. `props` are immutable: they are passed from the parent and are "owned" by the parent. To implement interactions, we introduce a mutable **state** to the component. `this.state` is private to the component and can be changed by calling `this.setState()` and passing an object that represents changes in state. When the state updates, the component re-renders itself.
 
 `render()` methods are written declaratively as functions of `this.props` and `this.state`. The framework guarantees the UI is always consistent with the inputs.
 
 When the server fetches data, we will be changing the comment data we have. Let's add an array of comment data to the `CommentBox` component as its state:
 
-```javascript{2-4,9}
-var CommentBox = React.createClass({
-  getInitialState: function() {
-    return {data: []};
-  },
-  render: function() {
+```javascript{2-5,10}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {data: []};
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -491,29 +493,31 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
-`getInitialState()` executes exactly once during the lifecycle of the component and sets up the initial state of the component.
+The `constructor()` executes exactly once during the lifecycle of the component and sets up the initial state of the component. Remember to call the super class (the class we're extending, React.Component) via `super(props)` before using the `this` keyword.
 
 #### Updating state
+
 When the component is first created, we want to GET some JSON from the server and update the state to reflect the latest data. We'll use the standard XMLHttpRequest API to retrieve the data. If you need support for old browsers (mainly old Internet Explorer), you can use an AJAX library or a multipurpose library such as jQuery. `componentWillMount()` executes immediately and only once before the rendering occurs. In the following example, `componentWillMount()` loads the data from our XMLHttpRequest and assigns it to the `data` variable. Finally, it sets the `data` variable in state, using `setState()`.
 
-```javascript{6-12}
-var CommentBox = React.createClass({
-  getInitialState: function() {
-    return {data: []};
-  },
-  componentWillMount: function() {
-    var xhr = new XMLHttpRequest();
+```javascript{6-14}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {data: []};
+  }
+  componentWillMount() {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', this.props.url, true);
-    xhr.onload = function() {
-      var data = JSON.parse(xhr.responseText);
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
       this.setState({ data: data });
-    }.bind(this);
+    };
     xhr.send();
-  },
-  render: function() {
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -522,30 +526,33 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
-Here, `componentDidMount()` is a method called automatically by React *after* a component is rendered for the first time. So, by moving the XMLHttpRequest call from `componentWillMount()`, which is executed only once *before* rendering, to a function called `loadCommentsFromServer()`, we can then call it multiple times from `componentDidMount()` at a set interval to check for any updates to the comments. The key to dynamic updates is the call to `this.setState()`. We replace the old array of comments with the new one from the server and the UI automatically updates itself. Because of this reactivity, it is only a minor change to add live updates. We will use simple polling here but you could easily use [SignalR](http://signalr.net/) or other technologies.
+Below, we're using `componentDidMount()`, a method called automatically by React *after* a component is rendered for the first time. By moving the XMLHttpRequest call from `componentWillMount()`, which is executed only once *before* rendering, to a function called `loadCommentsFromServer()`, we can then call it multiple times from `componentDidMount()` at a set interval to check for any updates to the comments.
 
-```javascript{2,15-16,30}
-var CommentBox = React.createClass({
-  loadCommentsFromServer: function() {
-    var xhr = new XMLHttpRequest();
+The key to these dynamic updates is the call to `this.setState()`. We replace the old array of comments with the new one from the server and the UI automatically updates itself. Because of this reactivity, it is only a minor change to add live updates. We will use simple polling here but you could easily use [SignalR](http://signalr.net/) or other technologies.
+
+```javascript{6,15-18,31}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { data: [] };
+  }
+  loadCommentsFromServer() {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', this.props.url, true);
-    xhr.onload = function() {
-      var data = JSON.parse(xhr.responseText);
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
       this.setState({ data: data });
-    }.bind(this);
+    };
     xhr.send();
-  },
-  getInitialState: function() {
-    return {data: []};
-  },
-  componentDidMount: function() {
+  }
+  componentDidMount() {
     this.loadCommentsFromServer();
-    window.setInterval(this.loadCommentsFromServer, this.props.pollInterval);
-  },
-  render: function() {
+    window.setInterval(() => this.loadCommentsFromServer(), this.props.pollInterval);
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -554,7 +561,7 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(
   <CommentBox url="/comments" pollInterval={2000} />,
@@ -578,6 +585,7 @@ public ActionResult AddComment(CommentModel comment)
 	return Content("Success :)");
 }
 ```
+
 Let's also add it to the `App_Start\RouteConfig.cs` file, like we did earlier for the comments list:
 
 ```csharp
@@ -594,8 +602,8 @@ routes.MapRoute(
 Now it's time to build the form. Our `CommentForm` component should ask the user for their name and comment text and send a request to the server to save the comment.
 
 ```javascript{4-8}
-var CommentForm = React.createClass({
-  render: function() {
+class CommentForm extends React.Component {
+  render() {
     return (
       <form className="commentForm">
         <input type="text" placeholder="Your name" />
@@ -604,27 +612,30 @@ var CommentForm = React.createClass({
       </form>
     );
   }
-});
+}
 ```
 
 #### Controlled components
 
-With the traditional DOM, `input` elements are rendered and the browser manages the state (its rendered value). As a result, the state of the actual DOM will differ from that of the component. This is not ideal as the state of the view will differ from that of the component. In React, components should always represent the state of the view and not only at the point of initialization.
+With the traditional DOM, `input` elements are rendered and the browser manages their state (its rendered value). As a result, the state of the actual DOM will differ from that of the component. This is not ideal as the state of the view will differ from that of the component. In React, components should always represent the state of the view and not only at the point of initialization.
 
-Hence, we will be using `this.state` to save the user's input as it is entered. We define an initial `state` with two properties `author` and `text` and set them to be empty strings. In our `<input>` elements, we set the `value` prop to reflect the `state` of the component and attach `onChange` handlers to them. These `<input>` elements with a `value` set are called controlled components. Read more about controlled components on the [Forms article](http://facebook.github.io/react/docs/forms.html#controlled-components).
+Hence, we will be using `this.state` to save the user's input as it is entered. We define an initial `state` with two properties `author` and `text` and set them to be empty strings. In our `<input>` elements, we set the `value` prop to reflect the `state` of the component and attach `onChange` handlers to them. These `<input>` elements with a `value` set are called controlled components. Read more about controlled components on the [Forms article](https://reactjs.org/docs/forms.html#controlled-components).
 
-```javascript{2-10,14-25}
-var CommentForm = React.createClass({
-  getInitialState: function() {
-    return {author: '', text: ''};
-  },
-  handleAuthorChange: function(e) {
+```javascript{2-13,16-28}
+class CommentForm extends React.Component {
+  constructor(props) {
+	  super(props);
+    this.state = {author: '', text: ''};
+		this.handleAuthorChange = this.handleAuthorChange.bind(this);
+    this.handleTextChange = this.handleTextChange.bind(this);
+  }
+  handleAuthorChange(e) {
     this.setState({author: e.target.value});
-  },
-  handleTextChange: function(e) {
+  }
+  handleTextChange(e) {
     this.setState({text: e.target.value});
-  },
-  render: function() {
+  }
+  render() {
     return (
       <form className="commentForm">
         <input
@@ -643,41 +654,45 @@ var CommentForm = React.createClass({
       </form>
     );
   }
-});
+}
 ```
 
 #### Events
 
 React attaches event handlers to components using a camelCase naming convention. We attach `onChange` handlers to the two `<input>` elements. Now, as the user enters text into the `<input>` fields, the attached `onChange` callbacks are fired and the `state` of the component is modified. Subsequently, the rendered value of the `input` element will be updated to reflect the current component `state`.
 
-(The astute reader may be surprised that these event handlers work as described, given that the method references are not explicitly bound to `this`. `React.createClass(...)` [automatically binds](/react/docs/interactivity-and-dynamic-uis.html#under-the-hood-autobinding-and-event-delegation) each method to its component instance, obviating the need for explicit binding.)
+You'll notice that we are explicitly binding our event handlers to `this` in the constructor. While older techniques, like `React.createClass(...)`, featured automatic binding, we are using ES6 classes to define our components. React components declared as ES6 classes don't automatically bind `this` to the instance, so we have to explicitly use `.bind(this)`.
 
 #### Submitting the form
 
 Let's make the form interactive. When the user submits the form, we should clear it, submit a request to the server, and refresh the list of comments. To start, let's listen for the form's submit event and clear it.
 
-```javascript{2-13,16-18,23}
-var CommentForm = React.createClass({
-  getInitialState: function() {
-    return {author: '', text: ''};
-  },
-  handleAuthorChange: function(e) {
+```javascript{7,15-24,27}
+class CommentForm extends React.Component {
+  constructor(props) {
+	  super(props);
+    this.state = {author: '', text: ''};
+		this.handleAuthorChange = this.handleAuthorChange.bind(this);
+    this.handleTextChange = this.handleTextChange.bind(this);
+		this.handleSubmit = this.handleSubmit.bind(this);
+  }
+  handleAuthorChange(e) {
     this.setState({author: e.target.value});
-  },
-  handleTextChange: function(e) {
+  }
+  handleTextChange(e) {
     this.setState({text: e.target.value});
-  },
-  handleSubmit: function(e) {
+  }
+	handleSubmit(e) {
     e.preventDefault();
-    var author = this.state.author.trim();
-    var text = this.state.text.trim();
+    const author = this.state.author.trim();
+    const text = this.state.text.trim();
     if (!text || !author) {
       return;
     }
     // TODO: send request to the server
-    this.setState({author: '', text: ''});
-  },
-  render: function() {
+    this.setState({ author: '', text: '' });
+  }
+  render() {
     return (
       <form className="commentForm" onSubmit={this.handleSubmit}>
         <input
@@ -696,41 +711,41 @@ var CommentForm = React.createClass({
       </form>
     );
   }
-});
+}
 ```
 
-We attach an `onSubmit` handler to the form that clears the form fields when the form is submitted with valid input.
-
-Call `preventDefault()` on the event to prevent the browser's default action of submitting the form.
+We attach an `onSubmit` handler to the form that clears the form fields when the form is submitted with valid input. We call `preventDefault()` on the event to prevent the browser's default action of submitting the form.
 
 #### Callbacks as props
 
 When a user submits a comment, we will need to refresh the list of comments to include the new one. It makes sense to do all of this logic in `CommentBox` since `CommentBox` owns the state that represents the list of comments.
 
-We need to pass data from the child component back up to its parent. We do this in our parent's `render` method by passing a new callback (`handleCommentSubmit`) into the child, binding it to the child's `onCommentSubmit` event. Whenever the event is triggered, the callback will be invoked:
+We need to pass data from the child component back up to its parent. We do this in our parent's `render` method by passing a new callback (`handleCommentSubmit`) into the child and binding it to the child's `onCommentSubmit` event. Whenever the event is triggered, the callback will be invoked:
 
-```javascript{11-13,26}
-var CommentBox = React.createClass({
-  loadCommentsFromServer: function() {
-    var xhr = new XMLHttpRequest();
+```javascript{5,16-18,28}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { data: [] };
+		this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
+  }
+  loadCommentsFromServer() {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', this.props.url, true);
-    xhr.onload = function() {
-      var data = JSON.parse(xhr.responseText);
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
       this.setState({ data: data });
-    }.bind(this);
+    };
     xhr.send();
-  },
-  handleCommentSubmit: function(comment) {
+  }
+	handleCommentSubmit(comment) {
     // TODO: submit to the server and refresh the list
-  },
-  getInitialState: function() {
-    return {data: []};
-  },
-  componentDidMount: function() {
+  }
+  componentDidMount() {
     this.loadCommentsFromServer();
-    window.setInterval(this.loadCommentsFromServer, this.props.pollInterval);
-  },
-  render: function() {
+    window.setInterval(() => this.loadCommentsFromServer(), this.props.pollInterval);
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -739,33 +754,37 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
 Now that `CommentBox` has made the callback available to `CommentForm` via the `onCommentSubmit` prop, the `CommentForm` can call the callback when the user submits the form:
 
-```javascript{18}
-var CommentForm = React.createClass({
-  getInitialState: function() {
-    return {author: '', text: ''};
-  },
-  handleAuthorChange: function(e) {
+```javascript{22}
+class CommentForm extends React.Component {
+  constructor(props) {
+	  super(props);
+    this.state = {author: '', text: ''};
+		this.handleAuthorChange = this.handleAuthorChange.bind(this);
+    this.handleTextChange = this.handleTextChange.bind(this);
+		this.handleSubmit = this.handleSubmit.bind(this);
+  }
+  handleAuthorChange(e) {
     this.setState({author: e.target.value});
-  },
-  handleTextChange: function(e) {
+  }
+  handleTextChange(e) {
     this.setState({text: e.target.value});
-  },
-  handleSubmit: function(e) {
+  }
+	handleSubmit(e) {
     e.preventDefault();
-    var author = this.state.author.trim();
-    var text = this.state.text.trim();
+    const author = this.state.author.trim();
+    const text = this.state.text.trim();
     if (!text || !author) {
       return;
     }
     this.props.onCommentSubmit({Author: author, Text: text});
-    this.setState({author: '', text: ''});
-  },
-  render: function() {
+    this.setState({ author: '', text: '' });
+  }
+  render() {
     return (
       <form className="commentForm" onSubmit={this.handleSubmit}>
         <input
@@ -784,42 +803,42 @@ var CommentForm = React.createClass({
       </form>
     );
   }
-});
+}
 ```
 
 Now that the callbacks are in place, all we have to do is submit to the server and refresh the list:
 
-```javascript{12-21,42}
-var CommentBox = React.createClass({
-  loadCommentsFromServer: function() {
-    var xhr = new XMLHttpRequest();
+```javascript{16-25,42}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { data: [] };
+		this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
+  }
+  loadCommentsFromServer() {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', this.props.url, true);
-    xhr.onload = function() {
-      var data = JSON.parse(xhr.responseText);
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
       this.setState({ data: data });
-    }.bind(this);
+    };
     xhr.send();
-  },
-  handleCommentSubmit: function(comment) {
-    var data = new FormData();
+  }
+	handleCommentSubmit(comment) {
+    const data = new FormData();
     data.append('Author', comment.Author);
     data.append('Text', comment.Text);
 
-    var xhr = new XMLHttpRequest();
+    const xhr = new XMLHttpRequest();
     xhr.open('post', this.props.submitUrl, true);
-    xhr.onload = function() {
-      this.loadCommentsFromServer();
-    }.bind(this);
+    xhr.onload = () => this.loadCommentsFromServer();
     xhr.send(data);
-  },
-  getInitialState: function() {
-    return {data: []};
-  },
-  componentDidMount: function() {
+  }
+  componentDidMount() {
     this.loadCommentsFromServer();
-    window.setInterval(this.loadCommentsFromServer, this.props.pollInterval);
-  },
-  render: function() {
+    window.setInterval(() => this.loadCommentsFromServer(), this.props.pollInterval);
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -828,7 +847,7 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(
   <CommentBox url="/comments" submitUrl="/comments/new" pollInterval={2000} />,
@@ -838,9 +857,9 @@ ReactDOM.render(
 
 ## Congrats!
 
-You have just built a comment box in a few simple steps. The below tweaks are not absolutely necessary, but they will improve the performance and polish of your application, so we suggest reading through them :)
+You have just built a comment box in a few simple steps. The below tweaks are not absolutely necessary, but they will improve the performance and polish of your application, so we suggest reading through them. :)
 
-We hope you have enjoyed learning about React, and how ReactJS.NET allows you to easily use it from an ASP.NET MVC web application. Learn more about [why to use React](http://facebook.github.io/react/docs/why-react.html) and how to [think about React components](http://facebook.github.io/react/docs/thinking-in-react.html), or dive into the [API reference](http://facebook.github.io/react/docs/top-level-api.html) and start hacking!
+We hope you have enjoyed learning about React and how ReactJS.NET allows you to easily use it from an ASP.NET MVC web application. Learn more about [React from the project homepage](https://reactjs.org/) and how to [think about React components](https://reactjs.org/docs/thinking-in-react.html), or dive into the [API reference](https://reactjs.org/docs/react-api.html) and start hacking!
 
 Continue on for more awesomeness!
 
@@ -848,45 +867,45 @@ Continue on for more awesomeness!
 
 Our application is now feature complete but it feels slow to have to wait for the request to complete before your comment appears in the list. We can optimistically add this comment to the list to make the app feel faster.
 
-```javascript{12-18}
-var CommentBox = React.createClass({
-  loadCommentsFromServer: function() {
-    var xhr = new XMLHttpRequest();
+```javascript{17-23}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { data: [] };
+		this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
+  }
+  loadCommentsFromServer() {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', this.props.url, true);
-    xhr.onload = function() {
-      var data = JSON.parse(xhr.responseText);
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
       this.setState({ data: data });
-    }.bind(this);
+    };
     xhr.send();
-  },
-  handleCommentSubmit: function(comment) {
-    var comments = this.state.data;
+  }
+	handleCommentSubmit(comment) {
+    const comments = this.state.data;
     // Optimistically set an id on the new comment. It will be replaced by an
     // id generated by the server. In a production application you would likely
-    // not use Date.now() for this and would have a more robust system in place.
-    comment.id = Date.now();
-    var newComments = comments.concat([comment]);
+    // use a more robust system for ID generation.
+    comment.Id = comments.length + 1;
+    const newComments = comments.concat([comment]);
     this.setState({data: newComments});
-
-    var data = new FormData();
+		
+    const data = new FormData();
     data.append('Author', comment.Author);
     data.append('Text', comment.Text);
 
-    var xhr = new XMLHttpRequest();
+    const xhr = new XMLHttpRequest();
     xhr.open('post', this.props.submitUrl, true);
-    xhr.onload = function() {
-      this.loadCommentsFromServer();
-    }.bind(this);
+    xhr.onload = () => this.loadCommentsFromServer();
     xhr.send(data);
-  },
-  getInitialState: function() {
-    return {data: []};
-  },
-  componentDidMount: function() {
+  }
+  componentDidMount() {
     this.loadCommentsFromServer();
-    window.setInterval(this.loadCommentsFromServer, this.props.pollInterval);
-  },
-  render: function() {
+    window.setInterval(() => this.loadCommentsFromServer(), this.props.pollInterval);
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -895,11 +914,12 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
 ## Optimization: Bundling and minification
-Bundling refers to the practice of combining multiple JavaScript files into a single large file to reduce the number of HTTP requests to load a page. Minification refers to the removal of comments and unnecessary whitespace from JavaScript files to make them smaller. Together, bundling and minification can help to significantly improve the performance of your website. ReactJS.NET supports ASP.NET Bundling and Minification to achieve this. You can refer to [Microsoft's official documentation](http://www.asp.net/mvc/tutorials/mvc-4/bundling-and-minification) for more information on ASP.NET Bundling and Minification. This tutorial will just cover the basics.
+
+Bundling refers to the practice of combining multiple JavaScript files into a single large file to reduce the number of HTTP requests to load a page. Minification refers to the removal of comments and unnecessary whitespace from JavaScript files to make them smaller. Together, bundling and minification can help to significantly improve the performance of your website. ReactJS.NET supports ASP.NET Bundling and Minification to achieve this. You can refer to [Microsoft's official documentation on Bundling and Minification](https://docs.microsoft.com/en-us/aspnet/mvc/overview/performance/bundling-and-minification). This tutorial will just cover the basics.
 
 To get started, install the "System.Web.Optimization.React" NuGet package. This will automatically install the ASP.NET Bundling and Minification package along with all its dependencies.
 
@@ -934,18 +954,18 @@ Now that the bundle has been registered, we need to reference it from the view:
 ```html{13}
 @model IEnumerable<ReactDemo.Models.CommentModel>
 @{
-    Layout = null;
+  Layout = null;
 }
 <html>
 <head>
-	<title>Hello React</title>
+  <title>Hello React</title>
 </head>
 <body>
-	<div id="content"></div>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.js"></script>
-	@Scripts.Render("~/bundles/main")
-	@Html.ReactInitJavaScript()
+  <div id="content"></div>
+  <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+  @Scripts.Render("~/bundles/main")
+  @Html.ReactInitJavaScript()
 </body>
 </html>
 ```
@@ -961,44 +981,45 @@ If you go to this URL in your browser, you should notice that the code has been 
 
 ## Optimization: Server-side rendering
 
-Server-side rendering means that your application initially renders the components on the server-side, rather than fetching data from the server and rendering using JavaScript. This enhances the performance of your application since the user will see the initial state immediately.
+Server-side rendering means that your application initially renders the components on the server-side, rather than fetching data from the server and rendering using the client. Server-side rendering enhances the performance of your application since the user will see the initial state immediately.
 
 We need to make some modifications to `CommentBox` to support server-side rendering. Firstly, we need to accept an `initialData` prop, which will be used to set the initial state of the component, rather than doing an AJAX request. We also need to remove the `loadCommentsFromServer` call from `componentDidMount`, since it is no longer required. Also, we need to remove the `ReactDOM.render` call from the JSX file, as server-side rendering automatically outputs the correct `ReactDOM.render` call for you.
 
-```javascript{28}
-var CommentBox = React.createClass({
-  loadCommentsFromServer: function() {
-    var xhr = new XMLHttpRequest();
+```javascript{4,31-33}
+class CommentBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { data: this.props.initialData };
+		this.handleCommentSubmit = this.handleCommentSubmit.bind(this);
+  }
+  loadCommentsFromServer() {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', this.props.url, true);
-    xhr.onload = function() {
-      var data = JSON.parse(xhr.responseText);
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
       this.setState({ data: data });
-    }.bind(this);
+    };
     xhr.send();
-  },
-  handleCommentSubmit: function(comment) {
-    var comments = this.state.data;
-    var newComments = comments.concat([comment]);
+  }
+	handleCommentSubmit(comment) {
+    const comments = this.state.data;
+    comment.Id = comments.length + 1;
+    const newComments = comments.concat([comment]);
     this.setState({data: newComments});
-
-    var data = new FormData();
+		
+    const data = new FormData();
     data.append('Author', comment.Author);
     data.append('Text', comment.Text);
 
-    var xhr = new XMLHttpRequest();
+    const xhr = new XMLHttpRequest();
     xhr.open('post', this.props.submitUrl, true);
-    xhr.onload = function() {
-      this.loadCommentsFromServer();
-    }.bind(this);
+    xhr.onload = () => this.loadCommentsFromServer();
     xhr.send(data);
-  },
-  getInitialState: function() {
-    return { data: this.props.initialData };
-  },
-  componentDidMount: function() {
-    window.setInterval(this.loadCommentsFromServer, this.props.pollInterval);
-  },
-  render: function() {
+  }
+  componentDidMount() {
+    window.setInterval(() => this.loadCommentsFromServer(), this.props.pollInterval);
+  }
+  render() {
     return (
       <div className="commentBox">
         <h1>Comments</h1>
@@ -1007,17 +1028,29 @@ var CommentBox = React.createClass({
       </div>
     );
   }
-});
+}
 ```
 
 We also need to update the `Comment` component to use `Remarkable` from either `global` or `window`, due to a bug in Remarkable:
+
 ```javascript{3}
-var Comment = React.createClass({
-	rawMarkup: function () {
-		var md = new (global.Remarkable || window.Remarkable)();
-		var rawMarkup = md.render(this.props.children.toString());
-		return { __html: rawMarkup };
-	},
+class Comment extends React.Component {
+  rawMarkup() {
+    const md = new (global.Remarkable || window.Remarkable)();
+    const rawMarkup = md.render(this.props.children.toString());
+    return { __html: rawMarkup };
+  }
+  render() {
+    return (
+      <div className="comment">
+        <h2 className="commentAuthor">
+          {this.props.author}
+        </h2>
+        <span dangerouslySetInnerHTML={this.rawMarkup()} />
+      </div>
+    );
+  }
+}
 ```
 
 In the view, we will accept the list of comments as the model, and use `Html.React` to render the component. This will replace the `ReactDOM.render` call that currently exists in Tutorial.jsx. All the props from the current `ReactDOM.render` call should be moved here, and the `ReactDOM.render` call should be deleted.
@@ -1025,25 +1058,25 @@ In the view, we will accept the list of comments as the model, and use `Html.Rea
 ```html{1,10-16,21}
 @model IEnumerable<ReactDemo.Models.CommentModel>
 @{
-    Layout = null;
+  Layout = null;
 }
 <html>
 <head>
-	<title>Hello React</title>
+  <title>Hello React</title>
 </head>
 <body>
-	@Html.React("CommentBox", new
-	{
-		initialData = Model,
-		url = Url.Action("Comments"),
-		submitUrl = Url.Action("AddComment"),
-		pollInterval = 2000,
-	})
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js"></script>
-	<script src="@Url.Content("~/Scripts/Tutorial.jsx")"></script>
-	@Html.ReactInitJavaScript()
+  @Html.React("CommentBox", new
+  {
+    initialData = Model,
+    url = Url.Action("Comments"),
+    submitUrl = Url.Action("AddComment"),
+    pollInterval = 2000
+  })
+  <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js"></script>
+  <script src="@Url.Content("~/Scripts/Tutorial.jsx")"></script>
+  @Html.ReactInitJavaScript()
 </body>
 </html>
 ```
@@ -1071,14 +1104,14 @@ namespace ReactDemo
 		public static void Configure()
 		{
 			ReactSiteConfiguration.Configuration
-				.AddScript("~/js/remarkable.min.js")
+				.AddScript("~/Scripts/remarkable.min.js")
 				.AddScript("~/Scripts/Tutorial.jsx");
 		}
 	}
 }
 ```
 
-Note that we need a copy of Remarkable in order to load it for server-side rendering. In a production app you'd probably use Bower or npm for this, but for our tutorial you can just [download the file from CDNJS](https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js) and save it into `~/js`.
+Note that we need a copy of Remarkable in order to load it for server-side rendering. In a production app you'd probably use Bower or npm for this, but for our tutorial you can just [download the file from CDNJS](https://cdnjs.cloudflare.com/ajax/libs/remarkable/1.7.1/remarkable.min.js) and save it into `~/Scripts`.
 
 That's it! Now if you build and refresh your application, you should notice that the comments box is rendered immediately rather than having a slight delay. If you view the source of the page, you will see the initial comments directly in the HTML itself:
 
@@ -1088,14 +1121,22 @@ That's it! Now if you build and refresh your application, you should notice that
   <title>Hello React</title>
 </head>
 <body>
-  <div id="react1">
-    <div class="commentBox" data-reactid=".2ged0u96as7" data-react-checksum="118121939">
-      <h1 data-reactid=".2ged0u96as7.0">Comments</h1>
-      <div class="commentList" data-reactid=".2ged0u96as7.1">
-        <div class="comment" data-reactid=".2ged0u96as7.1.0">
-          <h2 class="commentAuthor" data-reactid=".2ged0u96as7.1.0.0">Daniel Lo Nigro</h2>
-          <span data-reactid=".2ged0u96as7.1.0.1"><p>Hello ReactJS.NET World!</p></span>
+  <div id="react_CXgw1kvjbkOeUdVEzzi2g">
+    <div class="commentBox" data-reactroot="">
+      <h1>Comments</h1>
+      <div class="commentList">
+        <div class="comment">
+          <h2 class="commentAuthor">Daniel Lo Nigro</h2>
+          <span>Hello ReactJS.NET World!</span>
         </div>
-
-	<!-- Rest of the contents ommitted for brevity -->
+	<!-- ...snip... -->
 ```
+
+How is this magic possible? Well, React was built with server-side rendering in mind, so adding that capability to React.NET wasn't as magical as you'd think. React exposes [the ReactDOMServer object](https://reactjs.org/docs/react-dom-server.html) which enables a JavaScript engine to render a React component into static markup. From there, it's possible to "hydrate" that static markup in the client and make reactivity possible again. If you view the source of your page again, you will see a reference to `ReactDOM.hydrate()` where our `@Html.ReactInitJavaScript()` call is:
+
+```html
+  <!-- ...snip... -->
+  <script>ReactDOM.hydrate(React.createElement(CommentBox, {"initialData":[{"Id":1,"Author":"Daniel Lo Nigro","Text":"Hello ReactJS.NET World!"},{"Id":2,"Author":"Pete Hunt","Text":"This is one comment"},{"Id":3,"Author":"Jordan Walke","Text":"This is *another* comment"}],"url":"/comments","submitUrl":"/comments/new","pollInterval":2000}), document.getElementById("react_CXgw1kvjbkOeUdVEzzi2g"));</script>
+```
+
+**Note**, this hand-off between server and client means that you should ensure the version of React included in the browser is the same as in the NuGet package. If not, you may find yourself battling confusing errors or witnessing strange behavior. Check the [React.Web.Mvc4](https://www.nuget.org/packages/React.Web.Mvc4) and [React.Core](https://www.nuget.org/packages/React.Core/) packages for details.


### PR DESCRIPTION
I had issues that many others have had with getting the server rendering of this tutorial to work out of the box. I came to realize that it was a discrepancy in the version of React being used on the client versus in the NuGet package. NuGet was using the latest, version 16, but the client side code all referenced version 15. All sorts of confusion and chaos ensued.

This is a major change but it boils down to a shift over to ES6 classes instead of the older `React.createClass()` method. I tested as I went along, so the code should all work. I did not update screenshots. I think any reasonably seasoned .NET developer will skip over those details anyway. I am not a seasoned .NET developer, and I had no issues with that side of things.

I also added a note at the bottom explaining how server-side rendering can suffer from this version drift issue. Hopefully that will save people hours of debugging and frustration.