### PR TITLE
Added support of the JavaScript Engine Switcher version 3.0.0 Beta and JSPool version 3.1.0 Beta 1

### DIFF
--- a/src/React.Core/AssemblyRegistration.cs
+++ b/src/React.Core/AssemblyRegistration.cs
@@ -35,7 +35,7 @@ namespace React
 			// One instance shared for the whole app
 			container.Register<IReactSiteConfiguration>((c, o) => ReactSiteConfiguration.Configuration);
 			container.Register<IFileCacheHash, FileCacheHash>().AsPerRequestSingleton();
-			container.Register<JsEngineSwitcher>((c, o) => JsEngineSwitcher.Instance);
+			container.Register<IJsEngineSwitcher>((c, o) => JsEngineSwitcher.Current);
 			container.Register<IJavaScriptEngineFactory, JavaScriptEngineFactory>().AsSingleton();
 			container.Register<IReactIdGenerator, ReactIdGenerator>().AsSingleton();
 

--- a/src/React.Core/Exceptions/BabelException.cs
+++ b/src/React.Core/Exceptions/BabelException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when an error occurs when transforming a JavaScript file via Babel.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class BabelException : ReactException
@@ -33,7 +33,7 @@ namespace React.Exceptions
 		public BabelException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/BabelNotLoadedException.cs
+++ b/src/React.Core/Exceptions/BabelNotLoadedException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when Babel is required but has not been loaded.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class BabelNotLoadedException : ReactException
@@ -25,7 +25,7 @@ namespace React.Exceptions
 		/// </summary>
 		public BabelNotLoadedException() : base(GetMessage()) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ClearScriptV8InitialisationException.cs
+++ b/src/React.Core/Exceptions/ClearScriptV8InitialisationException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when the ClearScript V8 JavaScript engine fails to initialise
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ClearScriptV8InitialisationException : ReactException
@@ -26,7 +26,7 @@ namespace React.Exceptions
 		public ClearScriptV8InitialisationException(Exception innerException) :
 			base(GetMessage(innerException), innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactConfigurationException.cs
+++ b/src/React.Core/Exceptions/ReactConfigurationException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when an error occurs while reading a site configuration file.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactConfigurationException : ReactException
@@ -33,7 +33,7 @@ namespace React.Exceptions
 		public ReactConfigurationException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactEngineNotFoundException.cs
+++ b/src/React.Core/Exceptions/ReactEngineNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when no valid JavaScript engine is found.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactEngineNotFoundException : ReactException
@@ -31,7 +31,7 @@ namespace React.Exceptions
 		/// <param name="message">The message that describes the error.</param>
 		public ReactEngineNotFoundException(string message) : base(message) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactException.cs
+++ b/src/React.Core/Exceptions/ReactException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Base class for all ReactJS.NET exceptions
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactException : Exception
@@ -37,7 +37,7 @@ namespace React.Exceptions
 		public ReactException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactInvalidComponentException.cs
+++ b/src/React.Core/Exceptions/ReactInvalidComponentException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when a non-existent component is rendered.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactInvalidComponentException : ReactException
@@ -33,7 +33,7 @@ namespace React.Exceptions
 		public ReactInvalidComponentException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactNotInitialisedException.cs
+++ b/src/React.Core/Exceptions/ReactNotInitialisedException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when React has not been initialised correctly.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactNotInitialisedException : ReactException
@@ -34,7 +34,7 @@ namespace React.Exceptions
 		public ReactNotInitialisedException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactScriptLoadException.cs
+++ b/src/React.Core/Exceptions/ReactScriptLoadException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when an error is encountered while loading a JavaScript file.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactScriptLoadException : ReactException
@@ -34,7 +34,7 @@ namespace React.Exceptions
 		public ReactScriptLoadException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/ReactServerRenderingException.cs
+++ b/src/React.Core/Exceptions/ReactServerRenderingException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when an error occurs during server rendering of a React component.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class ReactServerRenderingException : ReactException
@@ -34,7 +34,7 @@ namespace React.Exceptions
 		public ReactServerRenderingException(string message, Exception innerException)
 			: base(message, innerException) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/Exceptions/VroomJsInitialisationException.cs
+++ b/src/React.Core/Exceptions/VroomJsInitialisationException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React.Exceptions
 	/// <summary>
 	/// Thrown when the VroomJs V8 JavaScript engine fails to initialise.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class VroomJsInitialisationException : ReactException
@@ -26,7 +26,7 @@ namespace React.Exceptions
 		public VroomJsInitialisationException(string innerMessage) : 
 			base(GetMessage(innerMessage)) { }
 
-#if NET40
+#if !NETSTANDARD1_6
 		/// <summary>
 		/// Used by deserialization
 		/// </summary>

--- a/src/React.Core/FileCacheHash.cs
+++ b/src/React.Core/FileCacheHash.cs
@@ -27,7 +27,7 @@ namespace React
 		/// <summary>
 		/// Algorithm for calculating file hashes
 		/// </summary>
-#if NET40
+#if NET40 || NET45
 		private readonly HashAlgorithm _hash = SHA1.Create("System.Security.Cryptography.SHA1Cng");
 #else
 		private readonly HashAlgorithm _hash = SHA1.Create();

--- a/src/React.Core/Initializer.cs
+++ b/src/React.Core/Initializer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -13,7 +13,7 @@ using System.Linq;
 using System.Reflection;
 using RegisterOptions = React.TinyIoC.TinyIoCContainer.RegisterOptions;
 
-#if !NET40
+#if !NET40 && !NET45
 using Microsoft.Extensions.DependencyModel;
 #endif
 
@@ -55,7 +55,7 @@ namespace React
 		private static void InitializeIoC(Func<RegisterOptions, RegisterOptions> requestLifetimeRegistration)
 		{
 			TinyIoCExtensions.AsRequestLifetime = requestLifetimeRegistration;
-#if NET40
+#if NET40 || NET45
 			var types = AppDomain.CurrentDomain.GetAssemblies()
 				// Only bother checking React assemblies
 				.Where(IsReactAssembly)

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Threading;
 using JavaScriptEngineSwitcher.Core;
 using JavaScriptEngineSwitcher.Msie;
-#if NET40
+#if NET45
 using JavaScriptEngineSwitcher.V8;
 #else
 using JavaScriptEngineSwitcher.ChakraCore;
@@ -37,7 +37,7 @@ namespace React
 		/// <summary>
 		/// The JavaScript Engine Switcher instance used by ReactJS.NET
 		/// </summary>
-		protected readonly JsEngineSwitcher _jsEngineSwitcher;
+		protected readonly IJsEngineSwitcher _jsEngineSwitcher;
 		/// <summary>
 		/// Contains all current JavaScript engine instances. One per thread, keyed on thread ID.
 		/// </summary>
@@ -60,7 +60,7 @@ namespace React
 		/// Initializes a new instance of the <see cref="JavaScriptEngineFactory"/> class.
 		/// </summary>
 		public JavaScriptEngineFactory(
-			JsEngineSwitcher jsEngineSwitcher,
+			IJsEngineSwitcher jsEngineSwitcher,
 			IReactSiteConfiguration config,
 			IFileSystem fileSystem
 		)
@@ -238,7 +238,7 @@ namespace React
 		/// The first functioning JavaScript engine with the lowest priority will be used.
 		/// </summary>
 		/// <returns>Function to create JavaScript engine</returns>
-		private static Func<IJsEngine> GetFactory(JsEngineSwitcher jsEngineSwitcher, bool allowMsie)
+		private static Func<IJsEngine> GetFactory(IJsEngineSwitcher jsEngineSwitcher, bool allowMsie)
 		{
 			EnsureJsEnginesRegistered(jsEngineSwitcher, allowMsie);
 
@@ -286,22 +286,22 @@ namespace React
 
 			// Epic fail, none of the engines worked. Nothing we can do now.
 			// Throw an error relevant to the engine they should be able to use.
-#if NET40
+#if NET45
 			if (JavaScriptEngineUtils.EnvironmentSupportsClearScript())
 			{
 				JavaScriptEngineUtils.EnsureEngineFunctional<V8JsEngine, ClearScriptV8InitialisationException>(
 					ex => new ClearScriptV8InitialisationException(ex)
 				);
 			}
+
 #endif
-#if NET40 || NETSTANDARD1_6
 			if (JavaScriptEngineUtils.EnvironmentSupportsVroomJs())
 			{
 				JavaScriptEngineUtils.EnsureEngineFunctional<VroomJsEngine, VroomJsInitialisationException>(
 					ex => new VroomJsInitialisationException(ex.Message)
 				);
 			}
-#endif
+
 			throw new ReactEngineNotFoundException();
 		}
 
@@ -362,7 +362,7 @@ namespace React
 		/// </summary>
 		/// <param name="jsEngineSwitcher">JavaScript Engine Switcher instance</param>
 		/// <param name="allowMsie">Whether to allow the MSIE JS engine</param>
-		private static void EnsureJsEnginesRegistered(JsEngineSwitcher jsEngineSwitcher, bool allowMsie)
+		private static void EnsureJsEnginesRegistered(IJsEngineSwitcher jsEngineSwitcher, bool allowMsie)
 		{
 			if (jsEngineSwitcher.EngineFactories.Any())
 			{
@@ -377,7 +377,7 @@ namespace React
 				"for more information."
 			);
 
-#if NET40
+#if NET45
 			jsEngineSwitcher.EngineFactories.AddV8();
 #endif
 			jsEngineSwitcher.EngineFactories.AddVroom();
@@ -385,7 +385,7 @@ namespace React
 			{
 				jsEngineSwitcher.EngineFactories.AddMsie();
 			}
-#if !NET40
+#if !NET45
 			jsEngineSwitcher.EngineFactories.AddChakraCore();
 #endif
 		}

--- a/src/React.Core/JavaScriptWithSourceMap.cs
+++ b/src/React.Core/JavaScriptWithSourceMap.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -15,7 +15,7 @@ namespace React
 	/// Represents the result of a Babel transformation along with its
 	/// corresponding source map.
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class JavaScriptWithSourceMap

--- a/src/React.Core/MemoryFileCache.cs
+++ b/src/React.Core/MemoryFileCache.cs
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#if NET40
+#if NET40 || NET45
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/React.Core/React.Core.csproj
+++ b/src/React.Core/React.Core.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright 2014-Present Facebook, Inc</Copyright>
     <AssemblyTitle>ReactJS.NET Core</AssemblyTitle>
     <Authors>Daniel Lo Nigro</Authors>
-    <TargetFrameworks>net40;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.6</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>React.Core</AssemblyName>
     <AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
@@ -16,7 +16,7 @@
     <PackageIconUrl>http://reactjs.net/img/logo_64.png</PackageIconUrl>
     <PackageProjectUrl>http://reactjs.net/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/reactjs/React.NET#licence</PackageLicenseUrl>
-	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,21 +32,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="2.4.8" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="2.4.9" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="2.4.9" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Vroom" Version="2.4.0" />
-    <PackageReference Include="JSPool" Version="3.0.1" />
-    <PackageReference Include="MsieJavaScriptEngine" Version="2.2.2" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-beta5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0-beta4" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0-beta5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Vroom" Version="3.0.0-beta4" />
+    <PackageReference Include="JSPool" Version="3.1.0-beta1" />
+    <PackageReference Include="MsieJavaScriptEngine" Version="3.0.0-beta4" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="VroomJs" Version="1.2.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.4.2" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.0.0-beta4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -221,14 +221,7 @@ namespace React
 		/// <param name="code">JavaScript to execute</param>
 		public virtual void Execute(string code)
 		{
-			try
-			{
-				Engine.Execute(code);
-			}
-			catch (JsRuntimeException ex)
-			{
-				throw WrapJavaScriptRuntimeException(ex);
-			}
+			Engine.Execute(code);
 		}
 
 		/// <summary>
@@ -239,14 +232,7 @@ namespace React
 		/// <returns>Result of the JavaScript code</returns>
 		public virtual T Execute<T>(string code)
 		{
-			try
-			{
-				return Engine.Evaluate<T>(code);
-			}
-			catch (JsRuntimeException ex)
-			{
-				throw WrapJavaScriptRuntimeException(ex);
-			}
+			return Engine.Evaluate<T>(code);
 		}
 
 		/// <summary>
@@ -258,14 +244,7 @@ namespace React
 		/// <returns>Result of the JavaScript code</returns>
 		public virtual T Execute<T>(string function, params object[] args)
 		{
-			try
-			{
-				return Engine.CallFunctionReturningJson<T>(function, args);
-			}
-			catch (JsRuntimeException ex)
-			{
-				throw WrapJavaScriptRuntimeException(ex);
-			}
+			return Engine.CallFunctionReturningJson<T>(function, args);
 		}
 
 		/// <summary>
@@ -275,14 +254,7 @@ namespace React
 		/// <returns><c>true</c> if the variable exists; <c>false</c> otherwise</returns>
 		public virtual bool HasVariable(string name)
 		{
-			try
-			{
-				return Engine.HasVariable(name);
-			}
-			catch (JsRuntimeException ex)
-			{
-				throw WrapJavaScriptRuntimeException(ex);
-			}
+			return Engine.HasVariable(name);
 		}
 
 		/// <summary>
@@ -389,7 +361,7 @@ namespace React
 			var engine = _engineFactory.GetEngineForCurrentThread();
 			EnsureBabelLoaded(engine);
 
-#if NET40
+#if NET40 || NET45
 			try
 			{
 				return engine.CallFunctionReturningJson<T>(function, args);
@@ -473,30 +445,6 @@ namespace React
 				_engineFromPool.Value.Dispose();
 				_engineFromPool = new Lazy<PooledJsEngine>(() => _engineFactory.GetEngine());
 			}
-		}
-
-		/// <summary>
-		/// Updates the Message of a <see cref="JsRuntimeException"/> to be more useful, containing
-		/// the line and column numbers.
-		/// </summary>
-		/// <param name="ex">Original exception</param>
-		/// <returns>New exception</returns>
-		protected virtual JsRuntimeException WrapJavaScriptRuntimeException(JsRuntimeException ex)
-		{
-			return new JsRuntimeException(string.Format(
-				"{0}\r\nLine: {1}\r\nColumn:{2}",
-				ex.Message,
-				ex.LineNumber,
-				ex.ColumnNumber
-			), ex.EngineName, ex.EngineVersion)
-			{
-				ErrorCode = ex.ErrorCode,
-				Category = ex.Category,
-				LineNumber = ex.LineNumber,
-				ColumnNumber = ex.ColumnNumber,
-				SourceFragment = ex.SourceFragment,
-				Source = ex.Source,
-			};
 		}
 
 		/// <summary>

--- a/src/React.Core/SourceMap.cs
+++ b/src/React.Core/SourceMap.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -17,7 +17,7 @@ namespace React
 	/// <summary>
 	/// Represents the data contained in a source map
 	/// </summary>
-#if NET40
+#if !NETSTANDARD1_6
 	[Serializable]
 #endif
 	public class SourceMap

--- a/src/React.Sample.Cassette/React.Sample.Cassette.csproj
+++ b/src/React.Sample.Cassette/React.Sample.Cassette.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -68,8 +68,8 @@
       <HintPath>..\packages\Cassette.Views.2.4.2\lib\net40\Cassette.Views.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0-beta4\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -198,7 +198,7 @@
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-	<OldVSToolsPath Condition="'$(OldVSToolsPath)' == ''">C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v14.0\</OldVSToolsPath>
+    <OldVSToolsPath Condition="'$(OldVSToolsPath)' == ''">C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v14.0\</OldVSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(OldVSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(OldVSToolsPath)' != ''" />

--- a/src/React.Sample.Cassette/Web.config
+++ b/src/React.Sample.Cassette/Web.config
@@ -53,16 +53,16 @@
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="a3a2846a37ac0d3e" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="AjaxMin" publicKeyToken="21ef50ce11b5d80f" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.14.5506.26196" newVersion="5.14.5506.26196" />
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="a3a2846a37ac0d3e" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.4.9.0" newVersion="2.4.9.0" />
+				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/src/React.Sample.Cassette/packages.config
+++ b/src/React.Sample.Cassette/packages.config
@@ -5,7 +5,7 @@
   <package id="Cassette.Aspnet" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.MSBuild" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Views" version="2.4.2" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0-beta4" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />

--- a/src/React.Sample.ConsoleApp/React.Sample.ConsoleApp.csproj
+++ b/src/React.Sample.ConsoleApp/React.Sample.ConsoleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>Copyright 2014-Present Facebook, Inc</Copyright>
@@ -10,7 +10,7 @@
     <PackageId>React.Sample.ConsoleApp</PackageId>
     <NoWarn>1701</NoWarn>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1</RuntimeFrameworkVersion>
-	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +26,12 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Sample.jsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/React.Sample.CoreMvc/React.Sample.CoreMvc.csproj
+++ b/src/React.Sample.CoreMvc/React.Sample.CoreMvc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
@@ -20,11 +20,11 @@
     <ProjectReference Include="..\React.AspNet\React.AspNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JavascriptEngineSwitcher.Chakracore" Version="2.4.18" />
-    <PackageReference Include="JavascriptEngineSwitcher.Extensions.MsDependencyInjection" Version="2.4.0" />
-    <PackageReference Include="JavascriptEngineSwitcher.Chakracore.native.linux-x64" Version="2.4.17" />
-    <PackageReference Include="JavascriptEngineSwitcher.Chakracore.native.osx-x64" Version="2.4.17" />
-    <PackageReference Include="JavascriptEngineSwitcher.Chakracore.native.win-x64" Version="2.4.17" />
+    <PackageReference Include="JavascriptEngineSwitcher.Chakracore" Version="3.0.0-beta5" />
+    <PackageReference Include="JavascriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.0.0-beta4" />
+    <PackageReference Include="JavascriptEngineSwitcher.Chakracore.native.linux-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavascriptEngineSwitcher.Chakracore.native.osx-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavascriptEngineSwitcher.Chakracore.native.win-x64" Version="3.0.0-beta3" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.0.0" PrivateAssets="All" />

--- a/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
+++ b/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -57,21 +58,21 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClearScript, Version=5.4.9.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net45\ClearScript.dll</HintPath>
+    <Reference Include="ClearScript, Version=5.5.2.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-beta4\lib\net45\ClearScript.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0-beta4\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Msie, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.2.4.9\lib\net45\JavaScriptEngineSwitcher.Msie.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Msie, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.3.0.0-beta5\lib\net45\JavaScriptEngineSwitcher.Msie.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.4.2.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.V8, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-beta4\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MsieJavaScriptEngine, Version=2.2.2.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
-      <HintPath>..\packages\MsieJavaScriptEngine.2.2.2\lib\net45\MsieJavaScriptEngine.dll</HintPath>
+    <Reference Include="MsieJavaScriptEngine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MsieJavaScriptEngine.3.0.0-beta4\lib\net45\MsieJavaScriptEngine.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -80,6 +81,9 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -223,6 +227,12 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/React.Sample.Mvc4/Web.config
+++ b/src/React.Sample.Mvc4/Web.config
@@ -52,29 +52,9 @@
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="C608B2A8CC9E4472" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.5.8.0" newVersion="1.5.8.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="A3A2846A37AC0D3E" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.7.0.0" newVersion="1.7.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="JavaScriptEngineSwitcher.Msie" publicKeyToken="C608B2A8CC9E4472" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="ClearScript" publicKeyToken="935D0C957DA47C73" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.4.5.0" newVersion="5.4.5.0" />
-			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.9.0" newVersion="2.4.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -85,16 +65,24 @@
         <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="JavaScriptEngineSwitcher.Msie" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <assemblyIdentity name="ClearScript" publicKeyToken="935D0C957DA47C73" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.5.2.0" newVersion="5.5.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="a3a2846a37ac0d3e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.2.0" newVersion="2.2.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="JavaScriptEngineSwitcher.Msie" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/React.Sample.Mvc4/packages.config
+++ b/src/React.Sample.Mvc4/packages.config
@@ -1,16 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.Msie" version="2.4.9" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8" version="2.4.2" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0-beta4" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.Msie" version="3.0.0-beta5" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8" version="3.0.0-beta4" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.0.0-beta3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net4" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net4" />
-  <package id="MsieJavaScriptEngine" version="2.2.2" targetFramework="net45" />
+  <package id="MsieJavaScriptEngine" version="3.0.0-beta4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />
 </packages>

--- a/src/React.Sample.Router.CoreMvc/React.Sample.Router.CoreMvc.csproj
+++ b/src/React.Sample.Router.CoreMvc/React.Sample.Router.CoreMvc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
@@ -6,11 +6,11 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore" Version="2.4.18" />
-    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore.native.linux-x64" Version="2.4.17" />
-    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore.native.osx-x64" Version="2.4.17" />
-    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore.native.win-x64" Version="2.4.17" />
-    <PackageReference Include="JavascriptEngineSwitcher.Extensions.MsDependencyInjection" Version="2.4.0" />
+    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore" Version="3.0.0-beta5" />
+    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore.native.linux-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore.native.osx-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavascriptEngineSwitcher.ChakraCore.native.win-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavascriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.0.0-beta4" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>

--- a/src/React.Sample.Webpack/React.Sample.Webpack.csproj
+++ b/src/React.Sample.Webpack/React.Sample.Webpack.csproj
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>React.Sample.Webpack</RootNamespace>
     <AssemblyName>React.Sample.Webpack</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -50,19 +51,22 @@
     <NoWarn>1607</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ClearScript, Version=5.4.9.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net40-client\ClearScript.dll</HintPath>
+    <Reference Include="ClearScript, Version=5.5.2.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-beta4\lib\net45\ClearScript.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0-beta4\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.4.2.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net40-client\JavaScriptEngineSwitcher.V8.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.V8, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-beta4\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -175,7 +179,7 @@
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-	<OldVSToolsPath Condition="'$(OldVSToolsPath)' == ''">C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v14.0\</OldVSToolsPath>
+    <OldVSToolsPath Condition="'$(OldVSToolsPath)' == ''">C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v14.0\</OldVSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(OldVSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(OldVSToolsPath)' != ''" />
@@ -201,6 +205,12 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/React.Sample.Webpack/Web.config
+++ b/src/React.Sample.Webpack/Web.config
@@ -15,7 +15,7 @@
 
   <system.web>
     
-    <compilation debug="true" targetFramework="4.0" />
+    <compilation debug="true" targetFramework="4.5" />
 
     <pages>
       <namespaces>
@@ -28,40 +28,33 @@
       </namespaces>
     </pages>
 
-		<httpHandlers>
-			<add verb="GET" path="*.jsx" type="React.Web.BabelHandlerFactory, React.Web, Version=2.0, Culture=neutral" />
-		</httpHandlers>
+    <httpHandlers>
+        <add verb="GET" path="*.jsx" type="React.Web.BabelHandlerFactory, React.Web, Version=2.0, Culture=neutral" />
+    </httpHandlers>
   </system.web>
 
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
-    
     <modules runAllManagedModulesForAllRequests="true" />
-
-		<handlers>
-			<remove name="Babel" />
-			<add name="Babel" verb="GET" path="*.jsx" type="React.Web.BabelHandlerFactory, React.Web, Version=2.0, Culture=neutral" preCondition="integratedMode" />
-		</handlers>
-    
+    <handlers>
+        <remove name="Babel" />
+        <add name="Babel" verb="GET" path="*.jsx" type="React.Web.BabelHandlerFactory, React.Web, Version=2.0, Culture=neutral" preCondition="integratedMode" />
+    </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="C608B2A8CC9E4472" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="ClearScript" publicKeyToken="935D0C957DA47C73" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.4.5.0" newVersion="5.4.5.0" />
-			</dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.9.0" newVersion="2.4.9.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
+        <dependentAssembly>
+            <assemblyIdentity name="ClearScript" publicKeyToken="935D0C957DA47C73" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-5.5.2.0" newVersion="5.5.2.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+            <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+            <assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="C608B2A8CC9E4472" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        </dependentAssembly>
     </assemblyBinding>
   </runtime>
 

--- a/src/React.Sample.Webpack/packages.config
+++ b/src/React.Sample.Webpack/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.V8" version="2.4.2" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0-beta4" targetFramework="net40" requireReinstallation="true" />
+  <package id="JavaScriptEngineSwitcher.V8" version="3.0.0-beta4" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.0.0-beta3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net40" />
 </packages>

--- a/tests/React.Tests.Benchmarks/Program.cs
+++ b/tests/React.Tests.Benchmarks/Program.cs
@@ -33,8 +33,8 @@ namespace React.Tests.Benchmarks
 				Initializer.Initialize(registration => registration.AsSingleton());
 				AssemblyRegistration.Container.Register<ICache, NullCache>();
 				AssemblyRegistration.Container.Register<IFileSystem, SimpleFileSystem>();
-				JsEngineSwitcher.Instance.EngineFactories.Add(new ChakraCoreJsEngineFactory());
-				JsEngineSwitcher.Instance.DefaultEngineName = ChakraCoreJsEngine.EngineName;
+				JsEngineSwitcher.Current.EngineFactories.Add(new ChakraCoreJsEngineFactory());
+				JsEngineSwitcher.Current.DefaultEngineName = ChakraCoreJsEngine.EngineName;
 
 				ReactSiteConfiguration.Configuration
 					.SetReuseJavaScriptEngines(false)

--- a/tests/React.Tests.Benchmarks/React.Tests.Benchmarks.csproj
+++ b/tests/React.Tests.Benchmarks/React.Tests.Benchmarks.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="benchmarkdotnet" Version="0.10.14" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="2.4.15" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="2.4.6" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-beta5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-beta3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello!

JavaScript Engine Switcher version 3.X has moved to the stabilization phase. I think that it's time to release beta version of the ReactJS.NET.

Main changes you can find in the [“How to upgrade applications to version 3.X”](https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/How-to-upgrade-applications-to-version-3.X) section of documentation.

I removed the <code title="React.ReactEnvironment.WrapJavaScriptRuntimeException">WrapJavaScriptRuntimeException</code> method, because it was no longer necessary. JavaScript Engine Switcher version 3.X now provides information about error location in the message:

```
------------------------------------------------------------
ChakraCoreJsEngine
------------------------------------------------------------
ReferenceError: 'n' is not defined
   at f (doc01.js:9:3) ->               n();
   at Global code (doc01.js:1:1)

------------------------------------------------------------
JintJsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at doc01.js:9:3

------------------------------------------------------------
JurassicJsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at f (doc01.js:9)
   at Global code (doc01.js:1)

------------------------------------------------------------
MsieJsEngine
------------------------------------------------------------
ReferenceError: 'n' is undefined
   at f (doc01.js:9:3)
   at Global code (doc01.js:1:1)

------------------------------------------------------------
NiLJsEngine
------------------------------------------------------------
ReferenceError: Variable "n" is not defined
   at 9:3 ->            n();

------------------------------------------------------------
V8JsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at f (doc01.js:9:3) ->               n();
   at doc01.js:1:1

------------------------------------------------------------
VroomJsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at doc01.js:9:3
```