### PR TITLE
Returned a list of missing globals in shims.js

### DIFF
--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -180,13 +180,14 @@ namespace React
 		/// <param name="engine">Engine to check</param>
 		private static void EnsureReactLoaded(IJsEngine engine)
 		{
-			var result = engine.CallFunction<bool>("ReactNET_initReact");
-			if (!result)
+			var result = engine.CallFunction<string[]>("ReactNET_initReact");
+			if (result.Length != 0)
 			{
 				throw new ReactNotInitialisedException(
-					"React has not been loaded correctly. Please expose your version of React as global " +
-					"variables named 'React', 'ReactDOM' and 'ReactDOMServer', or enable the " +
-					"'LoadReact' configuration option to use the built-in version of React."
+					$"React has not been loaded correctly: missing ({result.Join(", ")})." +
+					"Please expose your version of React as global variables named " +
+					"'React', 'ReactDOM' and 'ReactDOMServer', or enable the 'LoadReact'" +
+					"configuration option to use the built-in version of React."
 				);
 			}
 		}

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -184,7 +184,7 @@ namespace React
 			if (result.Length != 0)
 			{
 				throw new ReactNotInitialisedException(
-					$"React has not been loaded correctly: missing ({result.Join(", ")})." +
+					$"React has not been loaded correctly: missing ({String.Join(result, ", ")})." +
 					"Please expose your version of React as global variables named " +
 					"'React', 'ReactDOM' and 'ReactDOMServer', or enable the 'LoadReact'" +
 					"configuration option to use the built-in version of React."

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -184,7 +184,7 @@ namespace React
 			if (result.Length != 0)
 			{
 				throw new ReactNotInitialisedException(
-					$"React has not been loaded correctly: missing ({String.Join(result, ", ")})." +
+					$"React has not been loaded correctly: missing ({string.Join(", ", result)})." +
 					"Please expose your version of React as global variables named " +
 					"'React', 'ReactDOM', and 'ReactDOMServer', or enable the 'LoadReact'" +
 					"configuration option to use the built-in version of React."

--- a/src/React.Core/Resources/shims.js
+++ b/src/React.Core/Resources/shims.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright (c) 2014-Present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -46,26 +46,37 @@ if (!Object.freeze) {
 /**
  * Finds a user-supplied version of React and ensures it's exposed globally.
  *
- * @return {bool}
+ * @return {string[]} Which globals are missing, if any.
  */
 function ReactNET_initReact() {
-	if (
-		typeof React !== 'undefined' &&
-		typeof ReactDOM !== 'undefined' &&
-		typeof ReactDOMServer !== 'undefined'
-	) {
-		// React is already a global, woohoo
-		return true;
+	var missing = [];
+
+	if (typeof React === 'undefined') {
+		if (global.React) {
+			React = global.React;
+		} else {
+			missing.push('React');
+		}
 	}
 
-	if (global.React && global.ReactDOM && global.ReactDOMServer) {
-		React = global.React;
-		ReactDOM = global.ReactDOM;
-		ReactDOMServer = global.ReactDOMServer;
-		return true;
+	if (typeof ReactDOM === 'undefined') {
+		if (global.ReactDOM) {
+			ReactDOM = global.ReactDOM;
+		} else {
+			missing.push('ReactDOM');
+		}
 	}
-	// :'(
-	return false;
+
+	if (typeof ReactDOMServer === 'undefined') {
+		if (global.ReactDOMServer) {
+			ReactDOMServer = global.ReactDOMServer;
+		}
+		else {
+			missing.push('ReactDOMServer');
+		}
+	}
+
+	return missing;
 }
 
 setTimeout = setTimeout || global.setTimeout;

--- a/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
+++ b/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
@@ -125,7 +125,7 @@ namespace React.Tests.Core
 		{
 			var jsEngine = new Mock<IJsEngine>();
 			jsEngine.Setup(x => x.Evaluate<int>("1 + 1")).Returns(2);
-			jsEngine.Setup(x => x.CallFunction<bool>("ReactNET_initReact")).Returns(true);
+			jsEngine.Setup(x => x.CallFunction<string[]>("ReactNET_initReact")).Returns(new string[] { });
 			var config = new Mock<IReactSiteConfiguration>();
 			config.Setup(x => x.ScriptsWithoutTransform).Returns(new List<string>());
 			config.Setup(x => x.LoadReact).Returns(false);
@@ -134,7 +134,7 @@ namespace React.Tests.Core
 
 			factory.GetEngineForCurrentThread();
 
-			jsEngine.Verify(x => x.CallFunction<bool>("ReactNET_initReact"));
+			jsEngine.Verify(x => x.CallFunction<string[]>("ReactNET_initReact"));
 		}
 
 		[Fact]
@@ -142,7 +142,7 @@ namespace React.Tests.Core
 		{
 			var jsEngine = new Mock<IJsEngine>();
 			jsEngine.Setup(x => x.Evaluate<int>("1 + 1")).Returns(2);
-			jsEngine.Setup(x => x.CallFunction<bool>("ReactNET_initReact")).Returns(false);
+			jsEngine.Setup(x => x.CallFunction<string[]>("ReactNET_initReact")).Returns(new string[] { "React" });
 			var config = new Mock<IReactSiteConfiguration>();
 			config.Setup(x => x.ScriptsWithoutTransform).Returns(new List<string>());
 			config.Setup(x => x.LoadReact).Returns(false);


### PR DESCRIPTION
`EnsureReactLoaded` uses this to print out which ones are missing.

Fixes #569.