### PR TITLE
Fix for the `EnsureReactLoaded` method of `React.JavaScriptEngineFactory` class

### DIFF
--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -185,11 +185,13 @@ namespace React
 		/// <param name="engine">Engine to check</param>
 		private static void EnsureReactLoaded(IJsEngine engine)
 		{
-			var result = engine.CallFunction<string[]>("ReactNET_initReact");
-			if (result.Length != 0)
+			var globalsString = engine.CallFunction<string>("ReactNET_initReact");
+			string[] globals = globalsString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+			if (globals.Length != 0)
 			{
 				throw new ReactNotInitialisedException(
-					$"React has not been loaded correctly: missing ({string.Join(", ", result)})." +
+					$"React has not been loaded correctly: missing ({string.Join(", ", globals)})." +
 					"Please expose your version of React as global variables named " +
 					"'React', 'ReactDOM', and 'ReactDOMServer', or enable the 'LoadReact'" +
 					"configuration option to use the built-in version of React."

--- a/src/React.Core/Resources/shims.js
+++ b/src/React.Core/Resources/shims.js
@@ -46,7 +46,7 @@ if (!Object.freeze) {
 /**
  * Finds a user-supplied version of React and ensures it's exposed globally.
  *
- * @return {string[]} Which globals are missing, if any.
+ * @return {string} Comma-separated list of missing globals.
  */
 function ReactNET_initReact() {
 	var missing = [];
@@ -76,7 +76,7 @@ function ReactNET_initReact() {
 		}
 	}
 
-	return missing;
+	return missing.join(',');
 }
 
 setTimeout = setTimeout || global.setTimeout;

--- a/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
+++ b/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
@@ -126,7 +126,7 @@ namespace React.Tests.Core
 		{
 			var jsEngine = new Mock<IJsEngine>();
 			jsEngine.Setup(x => x.Evaluate<int>("1 + 1")).Returns(2);
-			jsEngine.Setup(x => x.CallFunction<string[]>("ReactNET_initReact")).Returns(new string[] { });
+			jsEngine.Setup(x => x.CallFunction<string>("ReactNET_initReact")).Returns(string.Empty);
 			var config = new Mock<IReactSiteConfiguration>();
 			config.Setup(x => x.ScriptsWithoutTransform).Returns(new List<string>());
 			config.Setup(x => x.LoadReact).Returns(false);
@@ -135,7 +135,7 @@ namespace React.Tests.Core
 
 			factory.GetEngineForCurrentThread();
 
-			jsEngine.Verify(x => x.CallFunction<string[]>("ReactNET_initReact"));
+			jsEngine.Verify(x => x.CallFunction<string>("ReactNET_initReact"));
 		}
 
 		[Fact]
@@ -143,7 +143,7 @@ namespace React.Tests.Core
 		{
 			var jsEngine = new Mock<IJsEngine>();
 			jsEngine.Setup(x => x.Evaluate<int>("1 + 1")).Returns(2);
-			jsEngine.Setup(x => x.CallFunction<string[]>("ReactNET_initReact")).Returns(new string[] { "React" });
+			jsEngine.Setup(x => x.CallFunction<string>("ReactNET_initReact")).Returns("React");
 			var config = new Mock<IReactSiteConfiguration>();
 			config.Setup(x => x.ScriptsWithoutTransform).Returns(new List<string>());
 			config.Setup(x => x.LoadReact).Returns(false);


### PR DESCRIPTION
Hello!

The following [line of code](https://github.com/reactjs/React.NET/blob/83785cf9ea6cea01341ca023a32b4086d5a14cfb/src/React.Core/JavaScriptEngineFactory.cs#L188):

```csharp
var result = engine.CallFunction<string[]>("ReactNET_initReact");
```

Will always cause an error:

```
System.ArgumentException: The type of return value `System.String[]` is not supported.
```

This error occurs, because the JavaScript Engine Switcher only supports primitive types. Here is a quote from the documentation:

> The supported .NET types are as follows:
> 
>  * `JavaScriptEngineSwitcher.Core.Undefined`
>  * `System.Boolean`
>  * `System.Int32`
>  * `System.Double`
>  * `System.String`

This PR contains the simplest fix for this error.
