### PR TITLE
Fix JS engine reloading in .NET Core

### DIFF
--- a/src/React.AspNet.Middleware/AspNetFileSystem.cs
+++ b/src/React.AspNet.Middleware/AspNetFileSystem.cs
@@ -1,9 +1,9 @@
-﻿/*
+/*
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Hosting;
 namespace React.AspNet
 {
 	/// <summary>
-	/// Handles file system functionality, such as reading files. Maps all paths from 
+	/// Handles file system functionality, such as reading files. Maps all paths from
 	/// application-relative (~/...) to full paths using ASP.NET's MapPath method.
 	/// </summary>
 	public class AspNetFileSystem : FileSystemBase
@@ -36,12 +36,12 @@ namespace React.AspNet
 		/// <returns>Full path of the file</returns>
 		public override string MapPath(string relativePath)
 		{
-            if (relativePath.StartsWith(_hostingEnv.WebRootPath))
-            {
-                return relativePath;
-            }
-            relativePath = relativePath.TrimStart('~').TrimStart('/');
-            return Path.Combine(_hostingEnv.WebRootPath, relativePath);
+			if (relativePath.StartsWith(_hostingEnv.WebRootPath))
+			{
+				return relativePath;
+			}
+			relativePath = relativePath.TrimStart('~').TrimStart('/').Replace("/", "\\");
+			return Path.Combine(_hostingEnv.WebRootPath, relativePath);
 		}
 	}
 }

--- a/src/React.AspNet.Middleware/AspNetFileSystem.cs
+++ b/src/React.AspNet.Middleware/AspNetFileSystem.cs
@@ -8,7 +8,6 @@
  */
 
 using System.IO;
-using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Hosting;
 
 namespace React.AspNet
@@ -41,15 +40,9 @@ namespace React.AspNet
 			{
 				return relativePath;
 			}
-
 			relativePath = relativePath.TrimStart('~').TrimStart('/');
 
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				relativePath = relativePath.Replace("/", "\\");
-			}
-
-			return Path.Combine(_hostingEnv.WebRootPath, relativePath);
+			return Path.GetFullPath(Path.Combine(_hostingEnv.WebRootPath, relativePath));
 		}
 	}
 }

--- a/src/React.AspNet.Middleware/AspNetFileSystem.cs
+++ b/src/React.AspNet.Middleware/AspNetFileSystem.cs
@@ -8,6 +8,7 @@
  */
 
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Hosting;
 
 namespace React.AspNet
@@ -40,7 +41,14 @@ namespace React.AspNet
 			{
 				return relativePath;
 			}
-			relativePath = relativePath.TrimStart('~').TrimStart('/').Replace("/", "\\");
+
+			relativePath = relativePath.TrimStart('~').TrimStart('/');
+
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				relativePath = relativePath.Replace("/", "\\");
+			}
+
 			return Path.Combine(_hostingEnv.WebRootPath, relativePath);
 		}
 	}

--- a/tests/React.Tests/Core/MiddlewareTests.cs
+++ b/tests/React.Tests/Core/MiddlewareTests.cs
@@ -1,5 +1,6 @@
 #if NETCOREAPP2_0
 
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Hosting;
 using Moq;
 using React.AspNet;
@@ -13,8 +14,16 @@ namespace React.Tests.Core
 		public void ForwardSlashesAreTransformed()
 		{
 			var environment = new Mock<IHostingEnvironment>();
-			environment.Setup(x => x.WebRootPath).Returns("c:\\temp");
-			Assert.Equal("c:\\temp\\wwwroot\\script.js", new AspNetFileSystem(environment.Object).MapPath("~/wwwroot/script.js"));
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				environment.Setup(x => x.WebRootPath).Returns("c:\\temp");
+				Assert.Equal("c:\\temp\\wwwroot\\script.js", new AspNetFileSystem(environment.Object).MapPath("~/wwwroot/script.js"));
+			}
+			else
+			{
+				environment.Setup(x => x.WebRootPath).Returns("/var/www");
+				Assert.Equal("/var/www/wwwroot/script.js", new AspNetFileSystem(environment.Object).MapPath("~/wwwroot/script.js"));
+			}
 		}
 	}
 }

--- a/tests/React.Tests/Core/MiddlewareTests.cs
+++ b/tests/React.Tests/Core/MiddlewareTests.cs
@@ -1,0 +1,21 @@
+#if NETCOREAPP2_0
+
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using React.AspNet;
+using Xunit;
+
+namespace React.Tests.Core
+{
+	public class MiddlewareTests
+    {
+		[Fact]
+		public void ForwardSlashesAreTransformed()
+		{
+			var environment = new Mock<IHostingEnvironment>();
+			environment.Setup(x => x.WebRootPath).Returns("c:\\temp");
+			Assert.Equal("c:\\temp\\wwwroot\\script.js", new AspNetFileSystem(environment.Object).MapPath("~/wwwroot/script.js"));
+		}
+	}
+}
+#endif

--- a/tests/React.Tests/React.Tests.csproj
+++ b/tests/React.Tests/React.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>Copyright 2014-Present Facebook, Inc</Copyright>
@@ -30,12 +30,16 @@
     <ProjectReference Include="..\..\src\React.Router\React.Router.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
Fixes #554 

It looks like this has never worked correctly with .NET Core...

JSPool looks for an exact match when a file changed event is raised, but we weren't first transforming the forwardslashes into backslashes.

<img width="812" alt="asdfasdfasdf" src="https://user-images.githubusercontent.com/942358/43998602-32cc3b12-9dae-11e8-8b14-b08c08b86352.PNG">