### PR TITLE
Fix insecure (non-HTTPS) links on site

### DIFF
--- a/site/jekyll/_config.yml
+++ b/site/jekyll/_config.yml
@@ -4,7 +4,7 @@ pygments: true
 permalink: /:year/:month/:title.html
 paginate: 5
 paginate_path: /blog/page:num.html
-url: http://reactjs.net
+url: https://reactjs.net
 doc-sections:
  - id: getting-started
    title: Getting Started

--- a/site/jekyll/_layouts/default.html
+++ b/site/jekyll/_layouts/default.html
@@ -9,7 +9,7 @@
   <meta property="og:title" content="{{ page.title }} | {{ site.name }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
-  <meta property="og:image" content="http://facebook.github.io/react/img/logo_og.png" />
+  <meta property="og:image" content="https://reactjs.org/logo-og.png" />
   <meta property="og:description" content=".NET integration for ReactJS" />
   <meta property="fb:app_id" content="1417169611875552" />
 


### PR DESCRIPTION
There's some non-HTTPS URLs:
```
  <meta property="og:url" content="http://reactjs.net/index.html" />
...
  <link rel="alternate" type="application/rss+xml" title="ReactJS.NET" href="http://reactjs.net/feed.xml" />
```

This should fix it.