### PR TITLE
"Current" property renamed to "Instance"

### DIFF
--- a/src/React.Sample.Mvc4/App_Start/ReactConfig.cs
+++ b/src/React.Sample.Mvc4/App_Start/ReactConfig.cs
@@ -23,8 +23,8 @@ namespace React.Sample.Mvc4
 				.SetAllowJavaScriptPrecompilation(true)
 				.AddScript("~/Content/Sample.jsx");
 
-			JsEngineSwitcher.Current.DefaultEngineName = V8JsEngine.EngineName;
-			JsEngineSwitcher.Current.EngineFactories.AddV8();
+			JsEngineSwitcher.Instance.DefaultEngineName = V8JsEngine.EngineName;
+			JsEngineSwitcher.Instance.EngineFactories.AddV8();
 		}
 	}
 }


### PR DESCRIPTION
I was following the ReactJS.NET Getting Started for ASP.NET 4.x and found that the "Current" property of JsEngineSwitcher has been replaced by "Instance" as seen here: 

https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/How-to-upgrade-applications-to-version-2.X