### PR TITLE
Update PackageLicenseUrl to point to LICENSE file

### DIFF
--- a/src/React.Web.Mvc4/React.Web.Mvc4.csproj
+++ b/src/React.Web.Mvc4/React.Web.Mvc4.csproj
@@ -16,7 +16,7 @@
     <PackageTags>asp.net;mvc;asp;jquery;javascript;js;react;facebook;reactjs;babel</PackageTags>
     <PackageIconUrl>http://reactjs.net/img/logo_64.png</PackageIconUrl>
     <PackageProjectUrl>http://reactjs.net/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/reactjs/React.NET#licence</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/reactjs/React.NET/blob/master/LICENSE</PackageLicenseUrl>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 


### PR DESCRIPTION
I think License info used to originally display in the README, and the former link would anchor down to it. This will take users to the correct place.