### PR TITLE
Improve chaining server-render helper functions

### DIFF
--- a/site/jekyll/features/css-in-js.md
+++ b/site/jekyll/features/css-in-js.md
@@ -9,6 +9,8 @@ CSS-in-JS is a technique for declaring styles within components. ReactJS.NET sup
 
 Make sure ReactJS.NET is up to date. You will need at least ReactJS.NET 4.0 (which is in public beta at the time of writing).
 
+If you're using more than one CSS-in-JS library in your project, we've got you covered! Just pass mutliple server-render helper functions into `ChainedRenderFunctions`, and they will be called in the order they are passed in.
+
 ### [Styled Components](https://github.com/styled-components/styled-components)
 
 Expose styled-components as `global.Styled`:
@@ -27,7 +29,7 @@ Add the render helper to the call to `Html.React`:
 	var styledComponentsFunctions = new StyledComponentsFunctions();
 }
 
-@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: styledComponentsFunctions)
+@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: new ChainedRenderFunctions(styledComponentsFunctions))
 
 @{
 	ViewBag.ServerStyles = styledComponentsFunctions.RenderedStyles;
@@ -104,7 +106,7 @@ Add the render helper to the call to `Html.React`:
 	var reactJssFunctions = new ReactJssFunctions();
 }
 
-@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: reactJssFunctions)
+@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: new ChainedRenderFunctions(reactJssFunctions))
 
 @{
 	ViewBag.ServerStyles = reactJssFunctions.RenderedStyles;
@@ -189,7 +191,7 @@ Add the render helper to the call to `Html.React`:
 @using React.AspNet
 @using React.RenderFunctions
 
-@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: new EmotionFunctions())
+@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: new ChainedRenderFunctions(new EmotionFunctions()))
 ```
 
 You're now ready to declare styles inside components:

--- a/site/jekyll/features/react-helmet.md
+++ b/site/jekyll/features/react-helmet.md
@@ -25,7 +25,7 @@ Add the render helper to the call to `Html.React`:
 	var helmetFunctions = new ReactHelmetFunctions();
 }
 
-@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: helmetFunctions)
+@Html.React("RootComponent", new { exampleProp = "a" }, renderFunctions: new ChainedRenderFunctions(helmetFunctions))
 
 @{
 	ViewBag.HelmetTitle = helmetFunctions.RenderedHelmet.GetValueOrDefault("title");

--- a/src/React.Core/RenderFunctions/ChainedRenderFunctions.cs
+++ b/src/React.Core/RenderFunctions/ChainedRenderFunctions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text;
 
 namespace React.RenderFunctions
@@ -9,7 +11,7 @@ namespace React.RenderFunctions
 	/// </summary>
 	public class ChainedRenderFunctions : IRenderFunctions
 	{
-		private readonly IRenderFunctions[] _chainedFunctions;
+		private readonly ReadOnlyCollection<IRenderFunctions> _chainedFunctions;
 
 		/// <summary>
 		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
@@ -17,7 +19,7 @@ namespace React.RenderFunctions
 		/// <param name="chainedFunctions">The chained render functions to call</param>
 		public ChainedRenderFunctions(params IRenderFunctions[] chainedFunctions)
 		{
-			_chainedFunctions = chainedFunctions;
+			_chainedFunctions = chainedFunctions.Where(x => x != null).ToList().AsReadOnly();
 		}
 
 		/// <summary>

--- a/src/React.Core/RenderFunctions/ChainedRenderFunctions.cs
+++ b/src/React.Core/RenderFunctions/ChainedRenderFunctions.cs
@@ -1,21 +1,37 @@
 using System;
+using System.Text;
 
-namespace React
+namespace React.RenderFunctions
 {
 	/// <summary>
-	/// Functions to execute during a render request.
-	/// These functions will share the same Javascript context, so state can be passed around via variables.
+	/// Helper to chain functions to be executed during server-side rendering.
+	/// For instance, React Router and React Helmet can both be used together using this class.
 	/// </summary>
-	public abstract class RenderFunctionsBase : IRenderFunctions
+	public class ChainedRenderFunctions : IRenderFunctions
 	{
+		private readonly IRenderFunctions[] _chainedFunctions;
+
+		/// <summary>
+		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
+		/// </summary>
+		/// <param name="chainedFunctions">The chained render functions to call</param>
+		public ChainedRenderFunctions(params IRenderFunctions[] chainedFunctions)
+		{
+			_chainedFunctions = chainedFunctions;
+		}
+
 		/// <summary>
 		/// Executes before component render.
 		/// It takes a func that accepts a Javascript code expression to evaluate, which returns the result of the expression.
 		/// This is useful for setting up variables that will be referenced after the render completes.
 		/// <param name="executeJs">The func to execute</param>
 		/// </summary>
-		public virtual void PreRender(Func<string, string> executeJs)
+		public void PreRender(Func<string, string> executeJs)
 		{
+			foreach (var chainedFunction in _chainedFunctions)
+			{
+				chainedFunction.PreRender(executeJs);
+			}
 		}
 
 
@@ -27,7 +43,17 @@ namespace React
 		/// </summary>
 		/// <param name="componentToRender">The Javascript expression to wrap</param>
 		/// <returns>A wrapped expression</returns>
-		public virtual string WrapComponent(string componentToRender) => componentToRender;
+		public string WrapComponent(string componentToRender)
+		{
+			string wrappedComponent = componentToRender;
+
+			foreach (var chainedFunction in _chainedFunctions)
+			{
+				wrappedComponent = chainedFunction.WrapComponent(wrappedComponent);
+			}
+
+			return wrappedComponent;
+		}
 
 
 		/// <summary>
@@ -36,7 +62,17 @@ namespace React
 		/// </summary>
 		/// <param name="input">The component HTML</param>
 		/// <returns>A wrapped expression</returns>
-		public virtual string TransformRenderedHtml(string input) => input;
+		public string TransformRenderedHtml(string input)
+		{
+			string renderedHtml = input;
+
+			foreach (var chainedFunction in _chainedFunctions)
+			{
+				renderedHtml = chainedFunction.TransformRenderedHtml(renderedHtml);
+			}
+
+			return renderedHtml;
+		}
 
 
 		/// <summary>
@@ -45,8 +81,12 @@ namespace React
 		/// This is useful for reading computed state, such as generated stylesheets or a router redirect result.
 		/// </summary>
 		/// <param name="executeJs">The func to execute</param>
-		public virtual void PostRender(Func<string, string> executeJs)
+		public void PostRender(Func<string, string> executeJs)
 		{
+			foreach (var chainedFunction in _chainedFunctions)
+			{
+				chainedFunction.PostRender(executeJs);
+			}
 		}
 	}
 }

--- a/src/React.Core/RenderFunctions/EmotionFunctions.cs
+++ b/src/React.Core/RenderFunctions/EmotionFunctions.cs
@@ -10,22 +10,11 @@ namespace React.RenderFunctions
 	public class EmotionFunctions : RenderFunctionsBase
 	{
 		/// <summary>
-		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
-		/// The functions within the provided RenderFunctions will be called *after* this instance's.
-		/// Supports null as an argument.
-		/// </summary>
-		/// <param name="renderFunctions">The chained render functions to call</param>
-		public EmotionFunctions(IRenderFunctions renderFunctions = null)
-			: base(renderFunctions)
-		{
-		}
-
-		/// <summary>
 		/// Implementation of TransformRenderedHtml
 		/// </summary>
 		/// <param name="input"></param>
 		/// <returns></returns>
-		protected override string TransformRenderedHtmlCore(string input)
+		public override string TransformRenderedHtml(string input)
 		{
 			return $"EmotionServer.renderStylesToString({input})";
 		}

--- a/src/React.Core/RenderFunctions/ReactHelmetFunctions.cs
+++ b/src/React.Core/RenderFunctions/ReactHelmetFunctions.cs
@@ -24,7 +24,7 @@ namespace React.RenderFunctions
 		public override void PostRender(Func<string, string> executeJs)
 		{
 			var helmetString = executeJs(@"
-var helmetResult = Helmet.default.renderStatic();
+var helmetResult = Helmet.renderStatic();
 JSON.stringify(['base', 'bodyAttributes', 'htmlAttributes', 'link', 'meta', 'noscript', 'script', 'style', 'title']
 	.reduce((mappedResults, helmetKey) => Object.assign(mappedResults, { [helmetKey]: helmetResult[helmetKey] && helmetResult[helmetKey].toString() }), {}));");
 

--- a/src/React.Core/RenderFunctions/ReactHelmetFunctions.cs
+++ b/src/React.Core/RenderFunctions/ReactHelmetFunctions.cs
@@ -12,17 +12,6 @@ namespace React.RenderFunctions
 	public class ReactHelmetFunctions : RenderFunctionsBase
 	{
 		/// <summary>
-		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
-		/// The functions within the provided RenderFunctions will be called *after* this instance's.
-		/// Supports null as an argument.
-		/// </summary>
-		/// <param name="renderFunctions">The chained render functions to call</param>
-		public ReactHelmetFunctions(IRenderFunctions renderFunctions = null)
-			: base(renderFunctions)
-		{
-		}
-
-		/// <summary>
 		/// Dictionary of Helmet properties, rendered as raw HTML tags
 		/// Available keys: "base", "bodyAttributes", "htmlAttributes", "link", "meta", "noscript", "script", "style", "title"
 		/// </summary>
@@ -32,7 +21,7 @@ namespace React.RenderFunctions
 		/// Implementation of PostRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PostRenderCore(Func<string, string> executeJs)
+		public override void PostRender(Func<string, string> executeJs)
 		{
 			var helmetString = executeJs(@"
 var helmetResult = Helmet.default.renderStatic();

--- a/src/React.Core/RenderFunctions/ReactJssFunctions.cs
+++ b/src/React.Core/RenderFunctions/ReactJssFunctions.cs
@@ -9,17 +9,6 @@ namespace React.RenderFunctions
 	public class ReactJssFunctions : RenderFunctionsBase
 	{
 		/// <summary>
-		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
-		/// The functions within the provided RenderFunctions will be called *after* this instance's.
-		/// Supports null as an argument.
-		/// </summary>
-		/// <param name="renderFunctions">The chained render functions to call</param>
-		public ReactJssFunctions(IRenderFunctions renderFunctions = null)
-			: base(renderFunctions)
-		{
-		}
-
-		/// <summary>
 		/// HTML style tag containing the rendered styles
 		/// </summary>
 		public string RenderedStyles { get; private set; }
@@ -28,7 +17,7 @@ namespace React.RenderFunctions
 		/// Implementation of PreRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PreRenderCore(Func<string, string> executeJs)
+		public override void PreRender(Func<string, string> executeJs)
 		{
 			executeJs("var reactJssProps = { registry: new ReactJss.SheetsRegistry() };");
 		}
@@ -38,7 +27,7 @@ namespace React.RenderFunctions
 		/// </summary>
 		/// <param name="componentToRender"></param>
 		/// <returns></returns>
-		protected override string WrapComponentCore(string componentToRender)
+		public override string WrapComponent(string componentToRender)
 		{
 			return ($"React.createElement(ReactJss.JssProvider, reactJssProps, ({componentToRender}))");
 		}
@@ -47,7 +36,7 @@ namespace React.RenderFunctions
 		/// Implementation of PostRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PostRenderCore(Func<string, string> executeJs)
+		public override void PostRender(Func<string, string> executeJs)
 		{
 			RenderedStyles = $"<style type=\"text/css\" id=\"server-side-styles\">{executeJs("reactJssProps.registry.toString()")}</style>";
 		}

--- a/src/React.Core/RenderFunctions/StyledComponentsFunctions.cs
+++ b/src/React.Core/RenderFunctions/StyledComponentsFunctions.cs
@@ -9,17 +9,6 @@ namespace React.RenderFunctions
 	public class StyledComponentsFunctions : RenderFunctionsBase
 	{
 		/// <summary>
-		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
-		/// The functions within the provided RenderFunctions will be called *after* this instance's.
-		/// Supports null as an argument.
-		/// </summary>
-		/// <param name="renderFunctions">The chained render functions to call</param>
-		public StyledComponentsFunctions(IRenderFunctions renderFunctions = null)
-			: base(renderFunctions)
-		{
-		}
-
-		/// <summary>
 		/// HTML style tag containing the rendered styles
 		/// </summary>
 		public string RenderedStyles { get; private set; }
@@ -28,7 +17,7 @@ namespace React.RenderFunctions
 		/// Implementation of PreRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PreRenderCore(Func<string, string> executeJs)
+		public override void PreRender(Func<string, string> executeJs)
 		{
 			executeJs("var serverStyleSheet = new Styled.ServerStyleSheet();");
 		}
@@ -38,7 +27,7 @@ namespace React.RenderFunctions
 		/// </summary>
 		/// <param name="componentToRender"></param>
 		/// <returns></returns>
-		protected override string WrapComponentCore(string componentToRender)
+		public override string WrapComponent(string componentToRender)
 		{
 			return ($"serverStyleSheet.collectStyles({componentToRender})");
 		}
@@ -47,7 +36,7 @@ namespace React.RenderFunctions
 		/// Implementation of PostRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PostRenderCore(Func<string, string> executeJs)
+		public override void PostRender(Func<string, string> executeJs)
 		{
 			RenderedStyles = executeJs("serverStyleSheet.getStyleTags()");
 		}

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -9,6 +9,7 @@
 
 using System.IO;
 using Newtonsoft.Json;
+using React.RenderFunctions;
 
 namespace React.Router
 {
@@ -56,12 +57,12 @@ namespace React.Router
 			IRenderFunctions renderFunctions = null
 		)
 		{
-			var reactRouterFunctions = new ReactRouterFunctions(renderFunctions: renderFunctions);
+			var reactRouterFunctions = new ReactRouterFunctions();
 
 			var html = RenderHtml(
 				renderContainerOnly,
 				renderServerOnly,
-				renderFunctions: reactRouterFunctions
+				renderFunctions: new ChainedRenderFunctions(renderFunctions, reactRouterFunctions)
 			);
 
 			return new ExecutionResult

--- a/src/React.Router/ReactRouterFunctions.cs
+++ b/src/React.Router/ReactRouterFunctions.cs
@@ -8,17 +8,6 @@ namespace React.Router
 	public class ReactRouterFunctions : RenderFunctionsBase
 	{
 		/// <summary>
-		/// Constructor. Supports chained calls to multiple render functions by passing in a set of functions that should be called next.
-		/// The functions within the provided RenderFunctions will be called *after* this instance's.
-		/// Supports null as an argument.
-		/// </summary>
-		/// <param name="renderFunctions">The chained render functions to call</param>
-		public ReactRouterFunctions(IRenderFunctions renderFunctions = null)
-			: base(renderFunctions)
-		{
-		}
-
-		/// <summary>
 		/// The returned react router context, as a JSON string
 		/// </summary>
 		public string ReactRouterContext { get; private set; }
@@ -27,7 +16,7 @@ namespace React.Router
 		/// Implementation of PreRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PreRenderCore(Func<string, string> executeJs)
+		public override void PreRender(Func<string, string> executeJs)
 		{
 			executeJs("var context = {};");
 		}
@@ -36,7 +25,7 @@ namespace React.Router
 		/// Implementation of PostRender
 		/// </summary>
 		/// <param name="executeJs"></param>
-		protected override void PostRenderCore(Func<string, string> executeJs)
+		public override void PostRender(Func<string, string> executeJs)
 		{
 			ReactRouterContext = executeJs("JSON.stringify(context);");
 		}

--- a/src/React.Sample.Webpack.CoreMvc/.babelrc
+++ b/src/React.Sample.Webpack.CoreMvc/.babelrc
@@ -1,6 +1,3 @@
 {
-	"presets": ["react", "env"],
-	"plugins": [
-		"add-module-exports"
-	]
+	"presets": ["react", "env"]
 }

--- a/src/React.Sample.Webpack.CoreMvc/Content/components/expose-components.js
+++ b/src/React.Sample.Webpack.CoreMvc/Content/components/expose-components.js
@@ -1,9 +1,20 @@
-require('expose-loader?React!react');
-require('expose-loader?ReactDOM!react-dom');
-require('expose-loader?ReactDOMServer!react-dom/server');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactDOMServer from 'react-dom/server';
 
-require('expose-loader?RootComponent!./home.jsx');
-require('expose-loader?Styled!styled-components');
-require('expose-loader?ReactJss!react-jss');
-require('expose-loader?EmotionServer!emotion-server');
-require('expose-loader?Helmet!react-helmet');
+import RootComponent from './home.jsx';
+import { ServerStyleSheet } from 'styled-components';
+import { JssProvider, SheetsRegistry } from 'react-jss';
+import { renderStylesToString } from 'emotion-server';
+import Helmet from 'react-helmet';
+
+global.React = React;
+global.ReactDOM = ReactDOM;
+global.ReactDOMServer = ReactDOMServer;
+
+global.Styled = { ServerStyleSheet };
+global.ReactJss = { JssProvider, SheetsRegistry };
+global.EmotionServer = { renderStylesToString };
+global.Helmet = Helmet;
+
+global.RootComponent = RootComponent;

--- a/src/React.Sample.Webpack.CoreMvc/Content/components/react-jss.jsx
+++ b/src/React.Sample.Webpack.CoreMvc/Content/components/react-jss.jsx
@@ -42,7 +42,7 @@ export class ReactJssDemo extends React.Component {
 				<Helmet>
 					<title>ReactJS.NET Demos | React-JSS</title>
 				</Helmet>
-				<WithInjectedSheet />;
+				<WithInjectedSheet />
 			</Fragment>
 		);
 	}

--- a/src/React.Sample.Webpack.CoreMvc/Views/Home/Index.cshtml
+++ b/src/React.Sample.Webpack.CoreMvc/Views/Home/Index.cshtml
@@ -5,11 +5,13 @@
 @{
 	Layout = "_Layout";
 	var emotionFunctions = new EmotionFunctions();
-	var styledComponentsFunctions = new StyledComponentsFunctions(emotionFunctions);
-	var reactJssFunctions = new ReactJssFunctions(styledComponentsFunctions);
-	var helmetFunctions = new ReactHelmetFunctions(reactJssFunctions);
+	var styledComponentsFunctions = new StyledComponentsFunctions();
+	var reactJssFunctions = new ReactJssFunctions();
+	var helmetFunctions = new ReactHelmetFunctions();
+
+	var chainedFunctions = new ChainedRenderFunctions(emotionFunctions, styledComponentsFunctions, reactJssFunctions, helmetFunctions);
 }
-@Html.ReactRouter("RootComponent", new { }, renderFunctions: helmetFunctions)
+@Html.ReactRouter("RootComponent", new { }, renderFunctions: chainedFunctions)
 @{
 	ViewBag.ServerStyles = styledComponentsFunctions.RenderedStyles + reactJssFunctions.RenderedStyles;
 	ViewBag.HelmetTitle = helmetFunctions.RenderedHelmet.GetValueOrDefault("title");

--- a/src/React.Sample.Webpack.CoreMvc/package-lock.json
+++ b/src/React.Sample.Webpack.CoreMvc/package-lock.json
@@ -1827,6 +1827,7 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -1848,7 +1849,8 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1862,7 +1864,8 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -1878,15 +1881,18 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -1949,7 +1955,8 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2058,6 +2065,7 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -2099,6 +2107,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -2110,7 +2119,8 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2297,7 +2307,8 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2330,6 +2341,7 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2378,7 +2390,8 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2398,6 +2411,7 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2428,6 +2442,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2437,6 +2452,7 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -2461,6 +2477,7 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -2510,7 +2527,8 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",

--- a/src/React.Sample.Webpack.CoreMvc/package.json
+++ b/src/React.Sample.Webpack.CoreMvc/package.json
@@ -9,12 +9,10 @@
   "dependencies": {
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.2",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "emotion": "^9.2.12",
     "emotion-server": "^9.2.12",
-    "expose-loader": "^0.7.3",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-emotion": "^9.2.12",

--- a/tests/React.Tests/Core/ReactComponentTest.cs
+++ b/tests/React.Tests/Core/ReactComponentTest.cs
@@ -11,6 +11,7 @@ using System;
 using JavaScriptEngineSwitcher.Core;
 using Moq;
 using React.Exceptions;
+using React.RenderFunctions;
 using Xunit;
 
 namespace React.Tests.Core
@@ -367,52 +368,48 @@ namespace React.Tests.Core
 		[Fact]
 		public void ChainedRenderFunctionsCalled()
 		{
-			var renderFunctions = new TestRenderFunctions();
-			var chainedRenderFunctions = new TestRenderFunctions(renderFunctions);
+			var firstInstance = new TestRenderFunctions();
+			var secondInstance = new TestRenderFunctions();
+			var chainedRenderFunctions = new ChainedRenderFunctions(firstInstance, secondInstance);
 
 			chainedRenderFunctions.PreRender(a => "prerender-result");
 
-			Assert.Equal("prerender-result", renderFunctions.PreRenderResult);
-			Assert.Equal("prerender-result", chainedRenderFunctions.PreRenderResult);
+			Assert.Equal("prerender-result", firstInstance.PreRenderResult);
+			Assert.Equal("prerender-result", secondInstance.PreRenderResult);
 
 			string wrapComponentResult = chainedRenderFunctions.WrapComponent("React.createElement('div', null)");
 			Assert.Equal("wrap(wrap(React.createElement('div', null)))", wrapComponentResult);
 
-			Assert.Equal("outerWrap(input)", renderFunctions.TransformRenderedHtml("input"));
+			Assert.Equal("outerWrap(input)", firstInstance.TransformRenderedHtml("input"));
 			Assert.Equal("outerWrap(outerWrap(input))", chainedRenderFunctions.TransformRenderedHtml("input"));
 
 			chainedRenderFunctions.PostRender(a => "postrender-result");
 
-			Assert.Equal("postrender-result", renderFunctions.PostRenderResult);
-			Assert.Equal("postrender-result", chainedRenderFunctions.PostRenderResult);
+			Assert.Equal("postrender-result", firstInstance.PostRenderResult);
+			Assert.Equal("postrender-result", secondInstance.PostRenderResult);
 		}
 
 		private sealed class TestRenderFunctions : RenderFunctionsBase
 		{
-			public TestRenderFunctions(IRenderFunctions renderFunctions = null)
-				: base(renderFunctions)
-			{
-			}
-
 			public string PreRenderResult { get; private set; }
 			public string PostRenderResult { get; private set; }
 
-			protected override void PreRenderCore(Func<string, string> executeJs)
+			public override void PreRender(Func<string, string> executeJs)
 			{
 				PreRenderResult = executeJs("prerender();");
 			}
 
-			protected override string WrapComponentCore(string componentToRender)
+			public override string WrapComponent(string componentToRender)
 			{
 				return $"wrap({componentToRender})";
 			}
 
-			protected override string TransformRenderedHtmlCore(string input)
+			public override string TransformRenderedHtml(string input)
 			{
 				return $"outerWrap({input})";
 			}
 
-			protected override void PostRenderCore(Func<string, string> executeJs)
+			public override void PostRender(Func<string, string> executeJs)
 			{
 				PostRenderResult = executeJs("postrender();");
 			}


### PR DESCRIPTION
It was always a bit clunky that the constructor was used for this. Now, there is a first-class ChainedRenderFunctions type that can be used to accomplish the same thing.