### PR TITLE
Update the JavaScript Engine Switcher to version 3.0.0

### DIFF
--- a/src/Cassette.React/Cassette.React.csproj
+++ b/src/Cassette.React/Cassette.React.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cassette" Version="2.4.2" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">

--- a/src/React.Core/React.Core.csproj
+++ b/src/React.Core/React.Core.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0" />
     <PackageReference Include="JSPool" Version="4.0.0-beta1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>

--- a/src/React.MSBuild/React.MSBuild.csproj
+++ b/src/React.MSBuild/React.MSBuild.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/React.Sample.Cassette/React.Sample.Cassette.csproj
+++ b/src/React.Sample.Cassette/React.Sample.Cassette.csproj
@@ -48,6 +48,9 @@
     <NoWarn>1607</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdvancedStringBuilder, Version=0.1.0.0, Culture=neutral, PublicKeyToken=e818a2fc08933ddb, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedStringBuilder.0.1.0\lib\net40-client\AdvancedStringBuilder.dll</HintPath>
+    </Reference>
     <Reference Include="AjaxMin, Version=5.14.5506.26196, Culture=neutral, PublicKeyToken=21ef50ce11b5d80f, processorArchitecture=MSIL">
       <HintPath>..\packages\AjaxMin.5.14.5506.26202\lib\net40\AjaxMin.dll</HintPath>
       <Private>True</Private>
@@ -69,14 +72,17 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0-rc1\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
     <Reference Include="JavaScriptEngineSwitcher.Msie, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.3.0.0-rc1\lib\net40-client\JavaScriptEngineSwitcher.Msie.dll</HintPath>
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.3.0.0\lib\net40-client\JavaScriptEngineSwitcher.Msie.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="MsieJavaScriptEngine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
-      <HintPath>..\packages\MsieJavaScriptEngine.3.0.0-rc1\lib\net40-client\MsieJavaScriptEngine.dll</HintPath>
+      <HintPath>..\packages\MsieJavaScriptEngine.3.0.0\lib\net40-client\MsieJavaScriptEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="PolyfillsForOldDotNet.System.Threading, Version=0.1.1.0, Culture=neutral, PublicKeyToken=7c096c79220f0d91, processorArchitecture=MSIL">
+      <HintPath>..\packages\PolyfillsForOldDotNet.System.Threading.0.1.1\lib\net40-client\PolyfillsForOldDotNet.System.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/React.Sample.Cassette/packages.config
+++ b/src/React.Sample.Cassette/packages.config
@@ -1,17 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdvancedStringBuilder" version="0.1.0" targetFramework="net40" />
   <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net40" />
   <package id="Cassette" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Aspnet" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.MSBuild" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Views" version="2.4.2" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0-rc1" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.Msie" version="3.0.0-rc1" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Msie" version="3.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="MsieJavaScriptEngine" version="3.0.0-rc1" targetFramework="net40" />
+  <package id="MsieJavaScriptEngine" version="3.0.0" targetFramework="net40" />
+  <package id="PolyfillsForOldDotNet.System.Threading" version="0.1.1" targetFramework="net40" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net40" />
 </packages>

--- a/src/React.Sample.ConsoleApp/React.Sample.ConsoleApp.csproj
+++ b/src/React.Sample.ConsoleApp/React.Sample.ConsoleApp.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
+++ b/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-rc1\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-rc1\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,18 +54,21 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdvancedStringBuilder, Version=0.1.0.0, Culture=neutral, PublicKeyToken=e818a2fc08933ddb, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedStringBuilder.0.1.0\lib\net45\AdvancedStringBuilder.dll</HintPath>
+    </Reference>
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClearScript, Version=5.5.3.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-rc1\lib\net45\ClearScript.dll</HintPath>
+    <Reference Include="ClearScript, Version=5.5.4.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0\lib\net45\ClearScript.dll</HintPath>
     </Reference>
     <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0-rc1\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
     <Reference Include="JavaScriptEngineSwitcher.V8, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-rc1\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -75,9 +78,6 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -225,7 +225,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-rc1\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-rc1\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/React.Sample.Mvc4/packages.config
+++ b/src/React.Sample.Mvc4/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdvancedStringBuilder" version="0.1.0" targetFramework="net45" />
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0-rc1" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8" version="3.0.0-rc1" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.0.0-rc1" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8" version="3.0.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net4" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />
 </packages>

--- a/src/React.Sample.Owin/React.Sample.Owin.csproj
+++ b/src/React.Sample.Owin/React.Sample.Owin.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x64" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x64" Version="3.0.0" />
     <PackageReference Include="Microsoft.Owin" Version="3.0.1" />
     <PackageReference Include="Microsoft.Owin.Diagnostics" Version="3.0.1" />
     <PackageReference Include="Microsoft.Owin.FileSystems" Version="3.0.1" />

--- a/src/React.Sample.Webpack.CoreMvc/React.Sample.Webpack.CoreMvc.csproj
+++ b/src/React.Sample.Webpack.CoreMvc/React.Sample.Webpack.CoreMvc.csproj
@@ -6,12 +6,12 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>

--- a/tests/React.Tests.Benchmarks/React.Tests.Benchmarks.csproj
+++ b/tests/React.Tests.Benchmarks/React.Tests.Benchmarks.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/React.Tests.Integration/React.Tests.Integration.csproj
+++ b/tests/React.Tests.Integration/React.Tests.Integration.csproj
@@ -4,11 +4,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0-rc1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-rc1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
Yesterday I released a [final version](https://github.com/Taritsyn/JavaScriptEngineSwitcher/releases/tag/v3.0.0) of the JavaScript Engine Switcher 3.0.0. This PR contains a simple upgrade of the JavaScript Engine Switcher's packages, and removing unnecessary dependency (System.Runtime.InteropServices.RuntimeInformation) from the React.Sample.Mvc4 project.