### PR TITLE
Catch all the JavaScript Engine Switcher's exceptions

### DIFF
--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -185,18 +185,16 @@ namespace React
 						engine.ExecuteFile(_fileSystem, file);
 					}
 				}
-				catch (JsScriptException ex)
+				catch (JsException ex)
 				{
 					// We can't simply rethrow the exception here, as it's possible this is running
 					// on a background thread (ie. as a response to a file changing). If we did
 					// throw the exception here, it would terminate the entire process. Instead,
 					// save the exception, and then just rethrow it later when getting the engine.
 					_scriptLoadException = new ReactScriptLoadException(string.Format(
-						"Error while loading \"{0}\": {1}\r\nLine: {2}\r\nColumn: {3}",
+						"Error while loading \"{0}\": {1}",
 						file,
-						ex.Message,
-						ex.LineNumber,
-						ex.ColumnNumber
+						ex.Message
 					));
 				}
 				catch (IOException ex)

--- a/src/React.Core/ReactComponent.cs
+++ b/src/React.Core/ReactComponent.cs
@@ -195,7 +195,7 @@ namespace React
 						return;
 					}
 				}
-				catch (JsRuntimeException ex)
+				catch (JsException ex)
 				{
 					if (exceptionHandler == null)
 					{

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -209,7 +209,7 @@ namespace React
 						Engine.Execute(contents, file);
 					}
 				}
-				catch (JsScriptException ex)
+				catch (JsException ex)
 				{
 					throw new ReactScriptLoadException(string.Format(
 						"Error while loading \"{0}\": {1}",

--- a/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
+++ b/tests/React.Tests/Core/JavaScriptEngineFactoryTest.cs
@@ -416,7 +416,7 @@ namespace React.Tests.Core
 			var factory = CreateFactory(config, cache, fileSystem, () => jsEngine.Object);
 
 			var ex = Assert.Throws<ReactScriptLoadException>(() => factory.GetEngineForCurrentThread());
-			Assert.Equal("Error while loading \"foo.js\": Fail\r\nLine: 42\r\nColumn: 911", ex.Message);
+			Assert.Equal("Error while loading \"foo.js\": Fail", ex.Message);
 		}
 
 		[Fact]
@@ -439,7 +439,7 @@ namespace React.Tests.Core
 			var factory = CreateFactory(config, cache, fileSystem, () => jsEngine.Object);
 
 			var ex = Assert.Throws<ReactScriptLoadException>(() => factory.GetEngineForCurrentThread());
-			Assert.Equal("Error while loading \"foo.js\": Fail\r\nLine: 42\r\nColumn: 911", ex.Message);
+			Assert.Equal("Error while loading \"foo.js\": Fail", ex.Message);
 		}
 
 		[Fact]


### PR DESCRIPTION
`JsScriptException` and `JsRuntimeException` classes cannot catch all errors that occur in JS engines (it is clearly seen from [exception hierarchy](https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/How-to-upgrade-applications-to-version-3.X#reorganization-of-exceptions)), therefore `JsException` class should be used instead. Also, I removed a line and column numbers from error messages, because the original error messages already contain them.

Here are some examples of the original error messages:

## Compilation errors

```
------------------------------------------------------------
ChakraCoreJsEngine
------------------------------------------------------------
SyntaxError: Invalid character
   at doc01.js:4:3 -> c @= 1;

------------------------------------------------------------
JintJsEngine
------------------------------------------------------------
SyntaxError: Unexpected token ILLEGAL
   at doc01.js:4:3

------------------------------------------------------------
JurassicJsEngine
------------------------------------------------------------
SyntaxError: Unexpected character '@'.
   at doc01.js:4

------------------------------------------------------------
MsieJsEngine
------------------------------------------------------------
SyntaxError: Invalid character
   at 4:3 -> c @= 1;

------------------------------------------------------------
NiLJsEngine
------------------------------------------------------------
SyntaxError: Unexpected token '@'
   at 4:3

------------------------------------------------------------
V8JsEngine
------------------------------------------------------------
SyntaxError: Invalid or unexpected token
   at doc01.js:4:3 -> c @= 1;

------------------------------------------------------------
VroomJsEngine
------------------------------------------------------------
SyntaxError: Unexpected token ILLEGAL
   at doc01.js:4:3
```

## Runtime errors

```
------------------------------------------------------------
ChakraCoreJsEngine
------------------------------------------------------------
ReferenceError: 'n' is not defined
   at f (doc01.js:9:3) ->               n();
   at Global code (doc01.js:1:1)

------------------------------------------------------------
JintJsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at doc01.js:9:3

------------------------------------------------------------
JurassicJsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at f (doc01.js:9)
   at Global code (doc01.js:1)

------------------------------------------------------------
MsieJsEngine
------------------------------------------------------------
ReferenceError: 'n' is undefined
   at f (doc01.js:9:3)
   at Global code (doc01.js:1:1)

------------------------------------------------------------
NiLJsEngine
------------------------------------------------------------
ReferenceError: Variable "n" is not defined
   at 9:3 ->            n();

------------------------------------------------------------
V8JsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at f (doc01.js:9:3) ->               n();
   at doc01.js:1:1

------------------------------------------------------------
VroomJsEngine
------------------------------------------------------------
ReferenceError: n is not defined
   at doc01.js:9:3
```