### PR TITLE
Add the Mono guide for ChakraCore

### DIFF
--- a/site/jekyll/getting-started/chakracore.md
+++ b/site/jekyll/getting-started/chakracore.md
@@ -39,6 +39,6 @@ For more information about registering Javascript engines, check out the [Javasc
 
 While Mono is supported, we strongly recommend using .NET Core instead.
 
-ReactJS.NET includes full support for Mono via Google's [V8 JavaScript engine](https://code.google.com/p/v8/), the same engine used by Google Chrome and Node.js. To use ReactJS.NET with Mono, follow the documentation on the [JavaScriptEngineSwitcher repo](https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/JS-Engine-Switcher:-Vroom) to build Vroom, and then register the JS Engine as the default in `Startup.cs`.
+To use ReactJS.NET with Mono, follow the documentation on the [JavaScriptEngineSwitcher repo](https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/ChakraCore#mono-support) to install ChakraCore, and then register the JS Engine as the default in `Startup.cs` or `ReactConfig.cs`.
 
-If VroomJs fails to load, you will see an exception when your application is started. If this happens, run Mono with the `MONO_LOG_LEVEL=debug` environment variable to get more useful debugging information. Often, this occurs when Mono is unable to locate V8 (ie. it's not in /usr/lib/ or /usr/local/lib/)
+If ChakraCore fails to load, you will see an exception when your application is started. If this happens, run Mono with the `MONO_LOG_LEVEL=debug` environment variable to get more useful debugging information.


### PR DESCRIPTION
When using ReactJS.NET version 4.0 with VroomJs now the following error occurs:

```
React.Core.Resources.react.generated.min.js: Uncaught ReferenceError: Set is not defined at line: 4 column: 69.
```
This error occurs because VroomJs is based on a very old version of V8 (version 3.17.16.2) that does not support modern ECMAScript. Therefore, it should be discarded, and use ChakraCore in the Mono runtime.
