### PR TITLE
Save original exceptions as inner exceptions

### DIFF
--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -195,11 +195,11 @@ namespace React
 						"Error while loading \"{0}\": {1}",
 						file,
 						ex.Message
-					));
+					), ex);
 				}
 				catch (IOException ex)
 				{
-					_scriptLoadException = new ReactScriptLoadException(ex.Message);
+					_scriptLoadException = new ReactScriptLoadException(ex.Message, ex);
 				}
 			}
 		}

--- a/src/React.Core/JavaScriptEngineUtils.cs
+++ b/src/React.Core/JavaScriptEngineUtils.cs
@@ -60,7 +60,7 @@ namespace React
 				throw new ReactException(string.Format(
 					"{0} did not return valid JSON: {1}.\n\n{2}",
 					function, ex.Message, resultJson
-				));
+				), ex);
 			}
 		}
 	}

--- a/src/React.Core/ReactEnvironment.cs
+++ b/src/React.Core/ReactEnvironment.cs
@@ -215,7 +215,7 @@ namespace React
 						"Error while loading \"{0}\": {1}",
 						file,
 						ex.Message
-					));
+					), ex);
 				}
 			}
 			Engine.SetVariableValue(USER_SCRIPTS_LOADED_KEY, true);

--- a/src/React.Core/ReactSiteConfiguration.cs
+++ b/src/React.Core/ReactSiteConfiguration.cs
@@ -50,7 +50,7 @@ namespace React
 					ComponentName,
 					ex.Message,
 					ContainerId
-				));
+				), ex);
 		}
 
 		/// <summary>


### PR DESCRIPTION
In some cases, information from the error message is not enough. Therefore, it is better to save original exceptions as inner exceptions.