### PR TITLE
Add NuGet package groupings to Renovate Bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,30 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "sourceUrlPrefixes": ["https://github.com/Taritsyn/JavaScriptEngineSwitcher"],
+      "groupName": "JavaScriptEngineSwitcher packages"
+    },
+    {
+      "sourceUrlPrefixes": ["https://github.com/aspnet/Extensions"],
+      "groupName": "ASP.NET Extensions"
+    },
+    {
+      "packagePatterns": ["^Microsoft.AspNetCore"],
+      "groupName": "ASP.NET Core packages"
+    },
+    {
+      "packagePatterns": ["^Microsoft.Owin"],
+      "groupName": "Owin packages"
+    },
+    {
+      "sourceUrlPrefixes": [
+        "https://github.com/aspnet/MetaPackages",
+        "https://github.com/aspnet/AspNetCore"
+      ],
+      "groupName": "ASP.NET Core packages"
+    }
   ]
 }


### PR DESCRIPTION
Adds the following (separate) groupings:
- All packages from @Taritsyn's JavascriptEngineSwitcher repo
- All packages from https://github.com/aspnet/Extensions
- `Microsoft.AspNetCore*` packages plus those with source repo https://github.com/aspnet/MetaPackages or https://github.com/aspnet/AspNetCore
- `Microsoft.Owin*` packages