### PR TITLE
Reduce the time of using the enumerator of `JsEngineFactoryCollection` class

### DIFF
--- a/src/Cassette.React/Cassette.React.csproj
+++ b/src/Cassette.React/Cassette.React.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Cassette" Version="2.4.2" />
     <PackageReference Include="Microsoft.Sourcelink.Github" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -289,13 +289,13 @@ namespace React
 				}
 			}
 
-			if (jsEngineSwitcher.EngineFactories.Count() == 0)
+			if (jsEngineSwitcher.EngineFactories.Count == 0)
 			{
 				throw new ReactException("No JS engines were registered. Visit https://reactjs.net/docs for more information.");
 			}
 
 			var exceptionMessages = new List<string>();
-			foreach (var engineFactory in jsEngineSwitcher.EngineFactories)
+			foreach (var engineFactory in jsEngineSwitcher.EngineFactories.GetRegisteredFactories())
 			{
 				IJsEngine engine = null;
 				try

--- a/src/React.Core/React.Core.csproj
+++ b/src/React.Core/React.Core.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.1.0" />
     <PackageReference Include="JSPool" Version="4.0.0" />
     <PackageReference Include="Microsoft.Sourcelink.Github" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/src/React.MSBuild/React.MSBuild.csproj
+++ b/src/React.MSBuild/React.MSBuild.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Msie" Version="3.1.0" />
     <PackageReference Include="Microsoft.Sourcelink.Github" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/React.Sample.Cassette/React.Sample.Cassette.csproj
+++ b/src/React.Sample.Cassette/React.Sample.Cassette.csproj
@@ -71,15 +71,15 @@
       <HintPath>..\packages\Cassette.Views.2.4.2\lib\net40\Cassette.Views.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.1.0\lib\net40-client\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Msie, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.3.0.0\lib\net40-client\JavaScriptEngineSwitcher.Msie.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Msie, Version=3.1.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Msie.3.1.0\lib\net40-client\JavaScriptEngineSwitcher.Msie.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MsieJavaScriptEngine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
-      <HintPath>..\packages\MsieJavaScriptEngine.3.0.0\lib\net40-client\MsieJavaScriptEngine.dll</HintPath>
+    <Reference Include="MsieJavaScriptEngine, Version=3.0.3.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MsieJavaScriptEngine.3.0.3\lib\net40-client\MsieJavaScriptEngine.dll</HintPath>
     </Reference>
     <Reference Include="PolyfillsForOldDotNet.System.Threading, Version=0.1.1.0, Culture=neutral, PublicKeyToken=7c096c79220f0d91, processorArchitecture=MSIL">
       <HintPath>..\packages\PolyfillsForOldDotNet.System.Threading.0.1.1\lib\net40-client\PolyfillsForOldDotNet.System.Threading.dll</HintPath>

--- a/src/React.Sample.Cassette/Web.config
+++ b/src/React.Sample.Cassette/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
@@ -63,11 +63,11 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="a3a2846a37ac0d3e" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-3.0.3.0" newVersion="3.0.3.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/src/React.Sample.Cassette/packages.config
+++ b/src/React.Sample.Cassette/packages.config
@@ -6,14 +6,14 @@
   <package id="Cassette.Aspnet" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.MSBuild" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Views" version="2.4.2" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0" targetFramework="net40" />
-  <package id="JavaScriptEngineSwitcher.Msie" version="3.0.0" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.1.0" targetFramework="net40" />
+  <package id="JavaScriptEngineSwitcher.Msie" version="3.1.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="MsieJavaScriptEngine" version="3.0.0" targetFramework="net40" />
+  <package id="MsieJavaScriptEngine" version="3.0.3" targetFramework="net40" />
   <package id="PolyfillsForOldDotNet.System.Threading" version="0.1.1" targetFramework="net40" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net40" />
 </packages>

--- a/src/React.Sample.ConsoleApp/React.Sample.ConsoleApp.csproj
+++ b/src/React.Sample.ConsoleApp/React.Sample.ConsoleApp.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
+++ b/src/React.Sample.Mvc4/React.Sample.Mvc4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" />
-  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" />
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -63,14 +63,14 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClearScript, Version=5.5.4.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0\lib\net45\ClearScript.dll</HintPath>
+    <Reference Include="ClearScript, Version=5.5.6.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.1.0\lib\net45\ClearScript.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.1.0\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.V8, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.V8, Version=3.1.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.1.0\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -227,8 +227,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
-    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props'))" />
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.1.0\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/React.Sample.Mvc4/Web.config
+++ b/src/React.Sample.Mvc4/Web.config
@@ -59,23 +59,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ClearScript" publicKeyToken="935D0C957DA47C73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.5.2.0" newVersion="5.5.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="MsieJavaScriptEngine" publicKeyToken="a3a2846a37ac0d3e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.5.6.0" newVersion="5.5.6.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="JavaScriptEngineSwitcher.Core" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="JavaScriptEngineSwitcher.Msie" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="JavaScriptEngineSwitcher.V8" publicKeyToken="c608b2a8cc9e4472" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />

--- a/src/React.Sample.Mvc4/packages.config
+++ b/src/React.Sample.Mvc4/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="AdvancedStringBuilder" version="0.1.0" targetFramework="net45" />
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8" version="3.0.0" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.0.0" targetFramework="net45" />
-  <package id="JavaScriptEngineSwitcher.V8.Native.win-x86" version="3.0.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.1.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8" version="3.1.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.1.0" targetFramework="net45" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x86" version="3.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.40804.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net4" />

--- a/src/React.Sample.Owin/React.Sample.Owin.csproj
+++ b/src/React.Sample.Owin/React.Sample.Owin.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x64" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Diagnostics" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.FileSystems" Version="3.1.0" />

--- a/src/React.Sample.Webpack.CoreMvc/React.Sample.Webpack.CoreMvc.csproj
+++ b/src/React.Sample.Webpack.CoreMvc/React.Sample.Webpack.CoreMvc.csproj
@@ -6,12 +6,12 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="2.2.0" />

--- a/tests/React.Tests.Benchmarks/React.Tests.Benchmarks.csproj
+++ b/tests/React.Tests.Benchmarks/React.Tests.Benchmarks.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/React.Tests.Integration/React.Tests.Integration.csproj
+++ b/tests/React.Tests.Integration/React.Tests.Integration.csproj
@@ -7,11 +7,11 @@
     <None Remove="Sample.jsx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.1.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
This will reduce the likelihood of problems such as [error #732](https://github.com/reactjs/React.NET/issues/732) “InvalidOperationException during JavaScriptEngineFactory.GetFactory”.