### PR TITLE
disabling ssr causes error in react router

### DIFF
--- a/runs-msbuild.bat
+++ b/runs-msbuild.bat
@@ -17,7 +17,7 @@ for %%s in (
 )
 
 :notfound
-echo Could not find MSBuild.exe. Make sure Visual Studio 2017 is installed and try again.
+echo Could not find MSBuild.exe. Make sure Visual Studio 2019 is installed and try again.
 
 :done
 pause

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -139,8 +139,8 @@ namespace React
 			LoadUserScripts(engine);
 			if (!_config.LoadReact && _scriptLoadException == null)
 			{
-				// We expect to user to have loaded their own version of React in the scripts that
-				// were loaded above, let's ensure that's the case.
+				// We expect the user to have loaded their own version of React in the scripts that
+				// were loaded above, let's ensure that's the case. 
 				EnsureReactLoaded(engine);
 			}
 		}

--- a/src/React.Core/Resources/babel-legacy/package-lock.json
+++ b/src/React.Core/Resources/babel-legacy/package-lock.json
@@ -4045,6 +4045,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.0.tgz",
+      "integrity": "sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -5103,9 +5109,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
-      "integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.3.tgz",
+      "integrity": "sha512-/qBxTvsxZ7bIFQtSa08QRY5BZuiJb27cbJM/nzmgXg9NEaudP20D7BruKKIuWfABqWoMEJQcNYYq/OxxSbPHlg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -5116,6 +5122,7 @@
         "import-local": "^2.0.0",
         "interpret": "^1.1.0",
         "loader-utils": "^1.1.0",
+        "prettier": "^1.17.0",
         "supports-color": "^5.5.0",
         "v8-compile-cache": "^2.0.2",
         "yargs": "^12.0.5"

--- a/src/React.Core/Resources/babel-legacy/package.json
+++ b/src/React.Core/Resources/babel-legacy/package.json
@@ -13,7 +13,7 @@
     "babel-preset-stage-0": "6.24.1",
     "babel-standalone": "6.26.0",
     "webpack": "4.33.0",
-    "webpack-cli": "3.3.2"
+    "webpack-cli": "3.3.3"
   },
   "author": "",
   "license": "MIT"

--- a/src/React.Core/package-lock.json
+++ b/src/React.Core/package-lock.json
@@ -3289,6 +3289,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.0.tgz",
+      "integrity": "sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4376,9 +4382,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
-      "integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.3.tgz",
+      "integrity": "sha512-/qBxTvsxZ7bIFQtSa08QRY5BZuiJb27cbJM/nzmgXg9NEaudP20D7BruKKIuWfABqWoMEJQcNYYq/OxxSbPHlg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -4389,6 +4395,7 @@
         "import-local": "^2.0.0",
         "interpret": "^1.1.0",
         "loader-utils": "^1.1.0",
+        "prettier": "^1.17.0",
         "supports-color": "^5.5.0",
         "v8-compile-cache": "^2.0.2",
         "yargs": "^12.0.5"

--- a/src/React.Core/package.json
+++ b/src/React.Core/package.json
@@ -12,6 +12,6 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "webpack": "4.33.0",
-    "webpack-cli": "3.3.2"
+    "webpack-cli": "3.3.3"
   }
 }

--- a/src/React.Router/ReactRouterFunctions.cs
+++ b/src/React.Router/ReactRouterFunctions.cs
@@ -9,8 +9,10 @@ namespace React.Router
 	{
 		/// <summary>
 		/// The returned react router context, as a JSON string
+		/// A default value wards off deserialization exceptions
+		/// when server side rendering is disabled
 		/// </summary>
-		public string ReactRouterContext { get; private set; }
+		public string ReactRouterContext { get; private set; } = "{}";
 
 		/// <summary>
 		/// Implementation of PreRender

--- a/src/React.Sample.Webpack.CoreMvc/Views/Home/Index.cshtml
+++ b/src/React.Sample.Webpack.CoreMvc/Views/Home/Index.cshtml
@@ -15,7 +15,7 @@
 @Html.ReactRouter("RootComponent", new { initialComments = Model.Comments, page = Model.Page }, renderFunctions: chainedFunctions)
 @{
 	ViewBag.ServerStyles = styledComponentsFunctions.RenderedStyles + reactJssFunctions.RenderedStyles;
-	ViewBag.HelmetTitle = helmetFunctions.RenderedHelmet.GetValueOrDefault("title");
+	ViewBag.HelmetTitle = helmetFunctions.RenderedHelmet?.GetValueOrDefault("title");
 }
 <script src="/dist/runtime.js"></script>
 <script src="/dist/vendor.js"></script>

--- a/src/React.Sample.Webpack.CoreMvc/package-lock.json
+++ b/src/React.Sample.Webpack.CoreMvc/package-lock.json
@@ -5056,6 +5056,12 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.0.tgz",
+      "integrity": "sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -6744,9 +6750,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
-      "integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.3.tgz",
+      "integrity": "sha512-/qBxTvsxZ7bIFQtSa08QRY5BZuiJb27cbJM/nzmgXg9NEaudP20D7BruKKIuWfABqWoMEJQcNYYq/OxxSbPHlg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -6757,6 +6763,7 @@
         "import-local": "^2.0.0",
         "interpret": "^1.1.0",
         "loader-utils": "^1.1.0",
+        "prettier": "^1.17.0",
         "supports-color": "^5.5.0",
         "v8-compile-cache": "^2.0.2",
         "yargs": "^12.0.5"

--- a/src/React.Sample.Webpack.CoreMvc/package.json
+++ b/src/React.Sample.Webpack.CoreMvc/package.json
@@ -27,6 +27,6 @@
     "babel-loader": "8.0.5",
     "babel-runtime": "6.26.0",
     "webpack": "4.33.0",
-    "webpack-cli": "3.3.2"
+    "webpack-cli": "3.3.3"
   }
 }


### PR DESCRIPTION
Hi guys, long time no see :)

There seems to be an error from at least 4.1.1 and onward (tried 4.2 and 5) which causes a null exception in 
React.Router.ReactRouterComponent.RenderRouterWithContext
line 69:
`JsonConvert.DeserializeObject<RoutingContext>(reactRouterFunctions.ReactRouterContext)`

This happens since when we disable SSR, ReactRouterFunctions never creates a context object in the js engine.

An extremely low effort quick fix follows, providing a default value for routerContext.
