### PR TITLE
Nuget symbol server

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -135,7 +135,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 		</ItemGroup>
 		<Exec
 			WorkingDirectory="$(MSBuildProjectDirectory)"
-			Command="tools\NuGet\nuget.exe push %(PackageFiles.Identity) -NonInteractive -Source https://www.nuget.org/api/v2/package -Symbols -SymbolPackageFormat snupkg"
+			Command="tools\NuGet\nuget.exe push %(PackageFiles.Identity) -NonInteractive -Source https://www.nuget.org/api/v2/package"
 		/>
 	</Target>
 	<Target Name="PushDev">

--- a/build.proj
+++ b/build.proj
@@ -135,7 +135,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 		</ItemGroup>
 		<Exec
 			WorkingDirectory="$(MSBuildProjectDirectory)"
-			Command="tools\NuGet\nuget.exe push %(PackageFiles.Identity) -NonInteractive -Source https://www.nuget.org/api/v2/package"
+			Command="tools\NuGet\nuget.exe push %(PackageFiles.Identity) -NonInteractive -Source https://www.nuget.org/api/v2/package -Symbols -SymbolPackageFormat snupkg"
 		/>
 	</Target>
 	<Target Name="PushDev">

--- a/src/Cassette.React/Cassette.React.csproj
+++ b/src/Cassette.React/Cassette.React.csproj
@@ -17,6 +17,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.AspNet.Middleware/React.AspNet.Middleware.csproj
+++ b/src/React.AspNet.Middleware/React.AspNet.Middleware.csproj
@@ -22,6 +22,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);ASPNETCORE</DefineConstants>
     <RootNamespace>React.AspNet</RootNamespace>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.AspNet/React.AspNet.csproj
+++ b/src/React.AspNet/React.AspNet.csproj
@@ -18,6 +18,8 @@
     <PackageLicense>https://github.com/reactjs/React.NET#licence</PackageLicense>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<DefineConstants>$(DefineConstants);ASPNETCORE</DefineConstants>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.Core/React.Core.csproj
+++ b/src/React.Core/React.Core.csproj
@@ -20,6 +20,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.Core/Resources/babel-legacy/package-lock.json
+++ b/src/React.Core/Resources/babel-legacy/package-lock.json
@@ -4045,6 +4045,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.0.tgz",
+      "integrity": "sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -5103,9 +5109,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
-      "integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.3.tgz",
+      "integrity": "sha512-/qBxTvsxZ7bIFQtSa08QRY5BZuiJb27cbJM/nzmgXg9NEaudP20D7BruKKIuWfABqWoMEJQcNYYq/OxxSbPHlg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -5116,6 +5122,7 @@
         "import-local": "^2.0.0",
         "interpret": "^1.1.0",
         "loader-utils": "^1.1.0",
+        "prettier": "^1.17.0",
         "supports-color": "^5.5.0",
         "v8-compile-cache": "^2.0.2",
         "yargs": "^12.0.5"

--- a/src/React.Core/Resources/babel-legacy/package.json
+++ b/src/React.Core/Resources/babel-legacy/package.json
@@ -13,7 +13,7 @@
     "babel-preset-stage-0": "6.24.1",
     "babel-standalone": "6.26.0",
     "webpack": "4.33.0",
-    "webpack-cli": "3.3.2"
+    "webpack-cli": "3.3.3"
   },
   "author": "",
   "license": "MIT"

--- a/src/React.Core/package-lock.json
+++ b/src/React.Core/package-lock.json
@@ -3289,6 +3289,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.0.tgz",
+      "integrity": "sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4376,9 +4382,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
-      "integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.3.tgz",
+      "integrity": "sha512-/qBxTvsxZ7bIFQtSa08QRY5BZuiJb27cbJM/nzmgXg9NEaudP20D7BruKKIuWfABqWoMEJQcNYYq/OxxSbPHlg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -4389,6 +4395,7 @@
         "import-local": "^2.0.0",
         "interpret": "^1.1.0",
         "loader-utils": "^1.1.0",
+        "prettier": "^1.17.0",
         "supports-color": "^5.5.0",
         "v8-compile-cache": "^2.0.2",
         "yargs": "^12.0.5"

--- a/src/React.Core/package.json
+++ b/src/React.Core/package.json
@@ -12,6 +12,6 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "webpack": "4.33.0",
-    "webpack-cli": "3.3.2"
+    "webpack-cli": "3.3.3"
   }
 }

--- a/src/React.MSBuild/React.MSBuild.csproj
+++ b/src/React.MSBuild/React.MSBuild.csproj
@@ -20,6 +20,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.Owin/React.Owin.csproj
+++ b/src/React.Owin/React.Owin.csproj
@@ -21,6 +21,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.Router.Mvc4/React.Router.Mvc4.csproj
+++ b/src/React.Router.Mvc4/React.Router.Mvc4.csproj
@@ -21,6 +21,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/React.Router/React.Router.csproj
+++ b/src/React.Router/React.Router.csproj
@@ -20,6 +20,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/React.Sample.Webpack.CoreMvc/package-lock.json
+++ b/src/React.Sample.Webpack.CoreMvc/package-lock.json
@@ -5056,6 +5056,12 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.0.tgz",
+      "integrity": "sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -6744,9 +6750,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
-      "integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.3.tgz",
+      "integrity": "sha512-/qBxTvsxZ7bIFQtSa08QRY5BZuiJb27cbJM/nzmgXg9NEaudP20D7BruKKIuWfABqWoMEJQcNYYq/OxxSbPHlg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -6757,6 +6763,7 @@
         "import-local": "^2.0.0",
         "interpret": "^1.1.0",
         "loader-utils": "^1.1.0",
+        "prettier": "^1.17.0",
         "supports-color": "^5.5.0",
         "v8-compile-cache": "^2.0.2",
         "yargs": "^12.0.5"

--- a/src/React.Sample.Webpack.CoreMvc/package.json
+++ b/src/React.Sample.Webpack.CoreMvc/package.json
@@ -27,6 +27,6 @@
     "babel-loader": "8.0.5",
     "babel-runtime": "6.26.0",
     "webpack": "4.33.0",
-    "webpack-cli": "3.3.2"
+    "webpack-cli": "3.3.3"
   }
 }

--- a/src/React.Web.Mvc4/React.Web.Mvc4.csproj
+++ b/src/React.Web.Mvc4/React.Web.Mvc4.csproj
@@ -21,6 +21,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/React.Web/React.Web.csproj
+++ b/src/React.Web/React.Web.csproj
@@ -20,6 +20,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuGet finally has a symbol server and it's easy to generate and upload compatible symbols.

This minor change ensures that the symbols get generated. 

Per my experience and according to the docs they then get uploaded with the *.nupkg with nuget push.

I did notice issue https://github.com/reactjs/React.NET/issues/467 but was unable to verify that and will assume that functionality is currently broken.

See https://blog.nuget.org/20181116/Improved-debugging-experience-with-the-NuGet-org-symbol-server-and-snupkg.html for more info.