### PR TITLE
ignore *.snupkg generated by  dev-build.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _old/
 src/SharedAssemblyVersionInfo.cs
 *.nupkg
+*.snupkg
 src/**/*.nuspec
 !src/template.nuspec
 site/jekyll/_site


### PR DESCRIPTION
These files are generated when we run `dev-build.bat`. They are kind of annoying when they keep showing in the change list.