### PR TITLE
Add support for loading scripts from webpack dev server

### DIFF
--- a/src/React.Core/IReactSiteConfiguration.cs
+++ b/src/React.Core/IReactSiteConfiguration.cs
@@ -228,5 +228,17 @@ namespace React
 		/// <param name="reactAppBuildPath"></param>
 		/// <returns></returns>
 		IReactSiteConfiguration SetReactAppBuildPath(string reactAppBuildPath);
+
+		/// <summary>
+		/// The URL to the local webpack dev server instance
+		/// </summary>
+		string WebpackDevServerUrl { get; set; }
+
+		/// <summary>
+		/// Sets the URL to the local webpack dev server instance
+		/// </summary>
+		/// <param name="webpackDevServerUrl"></param>
+		/// <returns></returns>
+		IReactSiteConfiguration SetWebpackDevServerUrl(string webpackDevServerUrl);
 	}
 }

--- a/src/React.Core/JavaScriptEngineFactory.cs
+++ b/src/React.Core/JavaScriptEngineFactory.cs
@@ -188,7 +188,7 @@ namespace React
 				manifest = ReactAppAssetManifest.LoadManifest(_config, _fileSystem, _cache, useCacheRead: false);
 			}
 
-			if (manifest != null)
+			if (manifest?.Entrypoints != null)
 			{
 				foreach (var file in manifest.Entrypoints?.Where(x => x != null && x.EndsWith(".js")))
 				{

--- a/src/React.Core/ReactAppAssetManifest.cs
+++ b/src/React.Core/ReactAppAssetManifest.cs
@@ -37,9 +37,9 @@ namespace React
 			return manifest;
 		}
 
-		public static ReactAppAssetManifest LoadManifestFromWebpackDevServer(IReactSiteConfiguration _config)
+		public static ReactAppAssetManifest LoadManifestFromWebpackDevServer(IReactSiteConfiguration config)
 		{
-			var manifestString = FetchStringFromUrl(new Uri(_config.WebpackDevServerUrl + "asset-manifest.json"));
+			var manifestString = FetchStringFromUrl(new Uri(config.WebpackDevServerUrl + "asset-manifest.json"));
 			return JsonConvert.DeserializeObject<ReactAppAssetManifest>(manifestString);
 		}
 
@@ -48,7 +48,7 @@ namespace React
 			// Really wish we could use HttpClient here, but no async is a recipe for potential deadlocks
 			// An async request pipeline would be needed to pull that off, which this library (today) has no concept of
 			var request = WebRequest.Create(url);
-			request.Timeout = 1000;
+			request.Timeout = 5000;
 			{
 				using (var response = (HttpWebResponse) request.GetResponse())
 				{

--- a/src/React.Core/ReactSiteConfiguration.cs
+++ b/src/React.Core/ReactSiteConfiguration.cs
@@ -375,5 +375,21 @@ namespace React
 			ReactAppBuildPath = reactAppBuildPath;
 			return this;
 		}
+
+		/// <summary>
+		/// The URL to the local webpack dev server instance
+		/// </summary>
+		public string WebpackDevServerUrl { get; set; }
+
+		/// <summary>
+		/// Sets URL to the local webpack dev server instance
+		/// </summary>
+		/// <param name="webpackDevServerUrl"></param>
+		/// <returns></returns>
+		public IReactSiteConfiguration SetWebpackDevServerUrl(string webpackDevServerUrl)
+		{
+			WebpackDevServerUrl = webpackDevServerUrl;
+			return this;
+		}
 	}
 }

--- a/src/React.Sample.Webpack.CoreMvc/Startup.cs
+++ b/src/React.Sample.Webpack.CoreMvc/Startup.cs
@@ -42,9 +42,8 @@ namespace React.Sample.Webpack.CoreMvc
 					.SetReuseJavaScriptEngines(true)
 					.SetLoadBabel(false)
 					.SetLoadReact(false)
-					.AddScriptWithoutTransform("~/dist/runtime.js")
-					.AddScriptWithoutTransform("~/dist/vendor.js")
-					.AddScriptWithoutTransform("~/dist/main.js");
+					.SetWebpackDevServerUrl("http://localhost:3000/")
+					.SetReactAppBuildPath("~/dist");
 
 				// Beta feature: Call .SetReactAppBuildPath("~/dist") to use the asset manifest instead of listing each file
 			});


### PR DESCRIPTION
Work in progress. This is necessary for create-react-app support, which does not write files to a dist folder during local development

Still needs some tests... also engine pooling doesn’t work correctly with this so need to fix that up 