### PR TITLE
Fix typo in tutorial-code.csproj

### DIFF
--- a/src/React.Template/reactnet-vanilla/tutorial-code.csproj
+++ b/src/React.Template/reactnet-vanilla/tutorial-code.csproj
@@ -7,7 +7,7 @@
 		<PackageId>tutorial-code</PackageId>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Include="App.config" />
+		<None Include="app.config" />
 		<None Update="wwwroot\**\*;Views\**\*;Areas\**\Views">
 			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
 		</None>


### PR DESCRIPTION
This typo was causing build failure because it points to a non-existent file.