### PR TITLE
Added support for relative paths (non-root webapplications)

### DIFF
--- a/src/React.AspNet/HtmlHelperExtensions.cs
+++ b/src/React.AspNet/HtmlHelperExtensions.cs
@@ -13,10 +13,12 @@ using System.Text;
 #if LEGACYASPNET
 using System.Web;
 using IHtmlHelper = System.Web.Mvc.HtmlHelper;
+using IUrlHelper = System.Web.Mvc.UrlHelper;
 #else
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Html;
 using IHtmlString = Microsoft.AspNetCore.Html.IHtmlContent;
+using Microsoft.AspNetCore.Mvc;
 #endif
 
 #if LEGACYASPNET
@@ -148,7 +150,7 @@ namespace React.AspNet
 			{
 				Environment.ReturnEngineToPool();
 			}
-	}
+		}
 
 		/// <summary>
 		/// Renders the JavaScript required to initialise all components client-side. This will
@@ -174,26 +176,28 @@ namespace React.AspNet
 		/// Returns script tags based on the webpack asset manifest
 		/// </summary>
 		/// <param name="htmlHelper"></param>
+		/// <param name="urlHelper">Optional IUrlHelper instance. Enables the use of tilde/relative (~/) paths inside the expose-components.js file.</param>
 		/// <returns></returns>
-		public static IHtmlString ReactGetScriptPaths(this IHtmlHelper htmlHelper)
+		public static IHtmlString ReactGetScriptPaths(this IHtmlHelper htmlHelper, IUrlHelper urlHelper = null)
 		{
 			string nonce = Environment.Configuration.ScriptNonceProvider != null
 				? $" nonce=\"{Environment.Configuration.ScriptNonceProvider()}\""
 				: "";
 
 			return new HtmlString(string.Join("", Environment.GetScriptPaths()
-				.Select(scriptPath => $"<script{nonce} src=\"{scriptPath}\"></script>")));
+				.Select(scriptPath => $"<script{nonce} src=\"{(urlHelper == null ? scriptPath : urlHelper.Content(scriptPath))}\"></script>")));
 		}
 
 		/// <summary>
 		/// Returns style tags based on the webpack asset manifest
 		/// </summary>
 		/// <param name="htmlHelper"></param>
+		/// <param name="urlHelper">Optional IUrlHelper instance. Enables the use of tilde/relative (~/) paths inside the expose-components.js file.</param>
 		/// <returns></returns>
-		public static IHtmlString ReactGetStylePaths(this IHtmlHelper htmlHelper)
+		public static IHtmlString ReactGetStylePaths(this IHtmlHelper htmlHelper, IUrlHelper urlHelper = null)
 		{
 			return new HtmlString(string.Join("", Environment.GetStylePaths()
-				.Select(stylePath => $"<link rel=\"stylesheet\" href=\"{stylePath}\" />")));
+				.Select(stylePath => $"<link rel=\"stylesheet\" href=\"{(urlHelper == null ? stylePath : urlHelper.Content(stylePath))}\" />")));
 		}
 
 		private static IHtmlString RenderToString(Action<StringWriter> withWriter)


### PR DESCRIPTION
Couldn't compile with all the \<Compile Include="..\SharedAssemblyVersionInfo.cs" /> lines, since those files were missing, so had to remove those to test. 

Relevant changes are in the **src/React.AspNet/HtmlHelperExtensions.cs** file.

In short: the best solution to implement these changes would be to have access to an IUrlHelper instance.
Since we call **@Html.ReactGetScriptPaths()** inside a view, we can change this to **@Html.ReactGetScriptPaths(Url)**.
This way we can have access to the IUrlHelper.Content(...) method and we can use a relative path inside our webpack.config:

```
new ManifestPlugin({
   fileName: "asset-manifest.json",
   publicPath: "~/dist/", <------------------------------------------
   generate: (seed, files) => {
      const manifestFiles = files.reduce((manifest, file) => {
         manifest[file.name] = file.path;
         return manifest;
      }, seed);

      const entrypointFiles = files.filter(x => x.isInitial && !x.name.endsWith('.map')).map(x => x.path);

      return {
         files: manifestFiles,
         entrypoints: entrypointFiles,
      };
   }
})
```

The generated **asset-manifest.json** file then looks like this:
```
{
  "files": {
    "main.css": "~/dist/main.styles.css",
    "main.js": "~/dist/main.80e487ae.js",
    "runtime.js": "~/dist/runtime.10bceee9.js",
    "vendor.js": "~/dist/vendor.8faee7f5.js"
  },
  "entrypoints": [
    "~/dist/main.styles.css",
    "~/dist/main.80e487ae.js",
    "~/dist/runtime.10bceee9.js",
    "~/dist/vendor.8faee7f5.js"
  ]
}
```
This then gets correctly translated when your website isn't hosted as root (e.g. as a subapplication inside iis).

**Successfully tested on a core 3.1 webapplication.**