### PR TITLE
React.Router ReactDOM.hydrate with ClientOnly #1140

### DIFF
--- a/src/React.Router/ReactEnvironmentExtensions.cs
+++ b/src/React.Router/ReactEnvironmentExtensions.cs
@@ -39,11 +39,11 @@ namespace React.Router
 				AssemblyRegistration.Container.Resolve<IReactIdGenerator>(),
 				componentName, 
 				containerId, 
-				path,
-				clientOnly
+				path
 			)
 			{
 				Props = props,
+				ClientOnly = clientOnly,
 			};
 
 			return env.CreateComponent(component, clientOnly) as ReactRouterComponent;

--- a/src/React.Router/ReactEnvironmentExtensions.cs
+++ b/src/React.Router/ReactEnvironmentExtensions.cs
@@ -39,7 +39,8 @@ namespace React.Router
 				AssemblyRegistration.Container.Resolve<IReactIdGenerator>(),
 				componentName, 
 				containerId, 
-				path
+				path,
+				clientOnly
 			)
 			{
 				Props = props,

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -30,15 +30,18 @@ namespace React.Router
 		/// <param name="componentName">Name of the component.</param>
 		/// <param name="containerId">The ID of the container DIV for this component</param>
 		/// <param name="path">F.x. from Request.Path. Used by React Static Router to determine context and routing.</param>
+		/// <param name="clientOnly">True if server-side rendering will be bypassed</param>
 		public ReactRouterComponent(
 			IReactEnvironment environment,
 			IReactSiteConfiguration configuration,
 			IReactIdGenerator reactIdGenerator,
 			string componentName,
 			string containerId,
-			string path
+			string path,
+			bool clientOnly
 		) : base(environment, configuration, reactIdGenerator, componentName, containerId)
 		{
+			ClientOnly = clientOnly;
 			_path = path;
 		}
 
@@ -97,12 +100,14 @@ namespace React.Router
 		/// <returns>JavaScript</returns>
 		public override void RenderJavaScript(TextWriter writer, bool waitForDOMContentLoad)
 		{
+			
 			if (waitForDOMContentLoad)
 			{
 				writer.Write("window.addEventListener('DOMContentLoaded', function() {");
 			}
 
-			writer.Write("ReactDOM.hydrate(");
+			writer.Write(
+				!_configuration.UseServerSideRendering || ClientOnly ? "ReactDOM.render(" : "ReactDOM.hydrate(");
 			base.WriteComponentInitialiser(writer);
 			writer.Write(", document.getElementById(\"");
 			writer.Write(ContainerId);

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -100,7 +100,6 @@ namespace React.Router
 		/// <returns>JavaScript</returns>
 		public override void RenderJavaScript(TextWriter writer, bool waitForDOMContentLoad)
 		{
-			
 			if (waitForDOMContentLoad)
 			{
 				writer.Write("window.addEventListener('DOMContentLoaded', function() {");

--- a/src/React.Router/ReactRouterComponent.cs
+++ b/src/React.Router/ReactRouterComponent.cs
@@ -30,18 +30,15 @@ namespace React.Router
 		/// <param name="componentName">Name of the component.</param>
 		/// <param name="containerId">The ID of the container DIV for this component</param>
 		/// <param name="path">F.x. from Request.Path. Used by React Static Router to determine context and routing.</param>
-		/// <param name="clientOnly">True if server-side rendering will be bypassed</param>
 		public ReactRouterComponent(
 			IReactEnvironment environment,
 			IReactSiteConfiguration configuration,
 			IReactIdGenerator reactIdGenerator,
 			string componentName,
 			string containerId,
-			string path,
-			bool clientOnly
+			string path
 		) : base(environment, configuration, reactIdGenerator, componentName, containerId)
 		{
-			ClientOnly = clientOnly;
 			_path = path;
 		}
 

--- a/tests/React.Tests/Router/HtmlHelperExtensionsTest.cs
+++ b/tests/React.Tests/Router/HtmlHelperExtensionsTest.cs
@@ -106,8 +106,7 @@ namespace React.Tests.Router
 					reactIdGenerator.Object,
 					"ComponentName",
 					"",
-					"/",
-					clientOnly
+					"/"
 				);
 				var execResult = new Mock<ExecutionResult>();
 

--- a/tests/React.Tests/Router/HtmlHelperExtensionsTest.cs
+++ b/tests/React.Tests/Router/HtmlHelperExtensionsTest.cs
@@ -92,7 +92,8 @@ namespace React.Tests.Router
 			public ReactRouterMocks(
 				Mock<IReactSiteConfiguration> conf,
 				Mock<IReactEnvironment> env,
-				Mock<IReactIdGenerator> idGenerator
+				Mock<IReactIdGenerator> idGenerator,
+				bool clientOnly = false
 			)
 			{
 				config = conf;
@@ -105,7 +106,8 @@ namespace React.Tests.Router
 					reactIdGenerator.Object,
 					"ComponentName",
 					"",
-					"/"
+					"/",
+					clientOnly
 				);
 				var execResult = new Mock<ExecutionResult>();
 
@@ -126,7 +128,7 @@ namespace React.Tests.Router
 			var config = ConfigureMockConfiguration();
 			var environment = ConfigureMockEnvironment();
 			var reactIdGenerator = ConfigureReactIdGenerator();
-			var routerMocks = new ReactRouterMocks(config, environment, reactIdGenerator);
+			var routerMocks = new ReactRouterMocks(config, environment, reactIdGenerator, true);
 			var htmlHelperMock = new HtmlHelperMocks();
 
 			environment.Verify(x => x.ReturnEngineToPool(), Times.Never);
@@ -150,7 +152,7 @@ namespace React.Tests.Router
 			var htmlHelperMock = new HtmlHelperMocks();
 			var environment = ConfigureMockEnvironment();
 			var reactIdGenerator = ConfigureReactIdGenerator();
-			var routerMocks = new ReactRouterMocks(config, environment, reactIdGenerator);
+			var routerMocks = new ReactRouterMocks(config, environment, reactIdGenerator, true);
 
 			var result = HtmlHelperExtensions.ReactRouter(
 				htmlHelper: htmlHelperMock.htmlHelper.Object,

--- a/tests/React.Tests/Router/ReactRouterComponentTest.cs
+++ b/tests/React.Tests/Router/ReactRouterComponentTest.cs
@@ -26,9 +26,10 @@ namespace React.Tests.Router
 			config.Setup(x => x.UseServerSideRendering).Returns(useServerSideRendering);
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
-			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar", clientOnly)
+			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar")
 			{
-				Props = new { hello = "World" }
+				Props = new { hello = "World" },
+				ClientOnly = clientOnly,
 			};
 			var result = component.RenderJavaScript(false);
 
@@ -61,9 +62,10 @@ namespace React.Tests.Router
 			config.Setup(x => x.UseServerSideRendering).Returns(useServerSideRendering);
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
-			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar", clientOnly)
+			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar")
 			{
-				Props = new { hello = "World" }
+				Props = new { hello = "World" },
+				ClientOnly = clientOnly
 			};
 			var result = component.RenderJavaScript(true);
 

--- a/tests/React.Tests/Router/ReactRouterComponentTest.cs
+++ b/tests/React.Tests/Router/ReactRouterComponentTest.cs
@@ -8,50 +8,78 @@
 
 using Moq;
 using Xunit;
-using React.Exceptions;
 using React.Router;
-using React.Tests.Core;
 
 namespace React.Tests.Router
 {
 	public class ReactRouterComponentTest
 	{
-		[Fact]
-		public void RenderJavaScriptShouldNotIncludeContextOrPath()
+		[Theory]
+		[InlineData(true, true)]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		[InlineData(false, false)]
+		public void RenderJavaScriptShouldNotIncludeContextOrPath(bool clientOnly, bool useServerSideRendering)
 		{
 			var environment = new Mock<IReactEnvironment>();
 			var config = new Mock<IReactSiteConfiguration>();
+			config.Setup(x => x.UseServerSideRendering).Returns(useServerSideRendering);
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
-			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar")
+			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar", clientOnly)
 			{
 				Props = new { hello = "World" }
 			};
 			var result = component.RenderJavaScript(false);
 
-			Assert.Equal(
-				@"ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
-				result
-			);
+			if (clientOnly || !useServerSideRendering)
+			{
+				Assert.Equal(
+					@"ReactDOM.render(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
+					result
+				);
+			} else
+			{
+				Assert.Equal(
+					@"ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
+					result
+				);
+			}
+			
 		}
 
-		[Fact]
-		public void RenderJavaScriptShouldHandleWaitForContentLoad()
+		[Theory]
+		[InlineData(true, true)]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		[InlineData(false, false)]
+		public void RenderJavaScriptShouldHandleWaitForContentLoad(bool clientOnly, bool useServerSideRendering)
 		{
 			var environment = new Mock<IReactEnvironment>();
 			var config = new Mock<IReactSiteConfiguration>();
+			config.Setup(x => x.UseServerSideRendering).Returns(useServerSideRendering);
 			var reactIdGenerator = new Mock<IReactIdGenerator>();
 
-			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar")
+			var component = new ReactRouterComponent(environment.Object, config.Object, reactIdGenerator.Object, "Foo", "container", "/bar", clientOnly)
 			{
 				Props = new { hello = "World" }
 			};
 			var result = component.RenderJavaScript(true);
 
-			Assert.Equal(
-				@"window.addEventListener('DOMContentLoaded', function() {ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))});",
-				result
-			);
+			if (clientOnly || !useServerSideRendering)
+			{
+				Assert.Equal(
+					@"window.addEventListener('DOMContentLoaded', function() {ReactDOM.render(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))});",
+					result
+				);
+			}
+			else
+			{
+				Assert.Equal(
+					@"window.addEventListener('DOMContentLoaded', function() {ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))});",
+					result
+				);
+			}
 		}
 	}
 }

--- a/tests/React.Tests/Router/ReactRouterComponentTest.cs
+++ b/tests/React.Tests/Router/ReactRouterComponentTest.cs
@@ -38,7 +38,8 @@ namespace React.Tests.Router
 					@"ReactDOM.render(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
 					result
 				);
-			} else
+			} 
+			else 
 			{
 				Assert.Equal(
 					@"ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))",
@@ -73,7 +74,7 @@ namespace React.Tests.Router
 					result
 				);
 			}
-			else
+			else 
 			{
 				Assert.Equal(
 					@"window.addEventListener('DOMContentLoaded', function() {ReactDOM.hydrate(React.createElement(Foo, {""hello"":""World""}), document.getElementById(""container""))});",


### PR DESCRIPTION
PR for issue #1140 

The override of `RenderJavaScript` in `ReactRouterComponent` could be removed since they are the same. But leaving it as an option.

Hope it's ok :)