### PR TITLE
Changed "Html.ReactInitJavascript" to "Html.ReactInitJavaScript"

### DIFF
--- a/site/jekyll/bundling/webpack.md
+++ b/site/jekyll/bundling/webpack.md
@@ -91,7 +91,7 @@ Reference the built bundle directly in a script tag at the end of the page in `_
   <script src="/dist/runtime.js"></script>
   <script src="/dist/vendor.js"></script>
   <script src="/dist/main.js"></script>
-  @Html.ReactInitJavascript()
+  @Html.ReactInitJavaScript()
 </body>
 ```
 
@@ -121,6 +121,6 @@ Then, make calls to `@Html.ReactGetScriptPaths()` and `@Html.ReactGetStylePaths(
   @RenderBody()
 
   @Html.ReactGetScriptPaths()
-  @Html.ReactInitJavascript()
+  @Html.ReactInitJavaScript()
 </body>
 ```


### PR DESCRIPTION
Struggled with this for a while, and I couldn't find a reason why "Html.ReactInitJavascript" didn't work.
Saw a post on stackoverflow where "Html.ReactInitJavaScript" was used, and noticed that the S should be uppercase.