### PR TITLE
Avoid the exception during Dispose by only calling SetObject() when t…

### DIFF
--- a/src/React.Web/TinyIoCAspNetExtensions.cs
+++ b/src/React.Web/TinyIoCAspNetExtensions.cs
@@ -63,9 +63,10 @@ namespace React.Web.TinyIoC
 			var item = GetObject() as IDisposable;
 
 			if (item != null)
+			{
 				item.Dispose();
-
-			SetObject(null);
+				SetObject(null);
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
The problem is that if an attempt is made to dispose the container or otherwise try to dispose the HttpContextLifetimeProvider from a thread where HttpContext.Current is null, a ReactAspNetException is thrown, aborting the entire disposal of the container. This fix addresses the problem by only calling SetObject(null); where there is reason to do so.