### PR TITLE
Ensure ? is included in path variable.

### DIFF
--- a/src/React.Router/HtmlHelperExtensions.cs
+++ b/src/React.Router/HtmlHelperExtensions.cs
@@ -102,7 +102,7 @@ namespace React.Router
 			{
 				var response = htmlHelper.ViewContext.HttpContext.Response;
 				var request = htmlHelper.ViewContext.HttpContext.Request;
-				var queryString = request.QueryString != null ? request.QueryString.ToString() : "";
+				var queryString = request != null && request.QueryString != null ? request.QueryString.ToString() : "";
 				if (!string.IsNullOrWhiteSpace(queryString) && !queryString.StartsWith("?"))
 				{
 					queryString = $"?{queryString}";


### PR DESCRIPTION
"?" character is not included in `request.QueryString` when run under .NET Framework whereas on .NET Core it does include it.

This check ensures that "?" is included when path variable is set.

Closes #1270