### PR TITLE
React 18 root support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+src/.idea

--- a/src/React.Core/IReactSiteConfiguration.cs
+++ b/src/React.Core/IReactSiteConfiguration.cs
@@ -228,5 +228,17 @@ namespace React
 		/// <param name="reactAppBuildPath"></param>
 		/// <returns></returns>
 		IReactSiteConfiguration SetReactAppBuildPath(string reactAppBuildPath);
+		
+		/// <summary>
+		/// Gets or sets if the React 18+ create root api should be used for rendering / hydration.
+		/// If false ReactDOM.render / ReactDOM.hydrate will be used. 
+		/// </summary>
+		bool UseRootAPI { get; set; }
+
+		/// <summary>
+		/// Enables usage of the React 18 root API when rendering / hydrating.
+		/// </summary>
+		/// <returns></returns>
+		void EnableReact18RootAPI();
 	}
 }

--- a/src/React.Core/ReactSiteConfiguration.cs
+++ b/src/React.Core/ReactSiteConfiguration.cs
@@ -375,5 +375,20 @@ namespace React
 			ReactAppBuildPath = reactAppBuildPath;
 			return this;
 		}
+		
+		/// <summary>
+		/// Gets or sets if the React 18+ create root api should be used for rendering / hydration.
+		/// If false ReactDOM.render / ReactDOM.hydrate will be used. 
+		/// </summary>
+		public bool UseRootAPI { get; set; }
+
+		/// <summary>
+		/// Enables usage of the React 18 root API when rendering / hydrating.
+		/// </summary>
+		/// <returns></returns>
+		public void EnableReact18RootAPI()
+		{
+			UseRootAPI = true;
+		}
 	}
 }


### PR DESCRIPTION
fixes #1285 
This is mostly unrelated to #1265 and still uses the renderToString API

#### Things that should probably be done before this is merged (happy to help with this if you want)
1. Update the documentation.
2. Update the code for ReactRouter to make this work there as well.

I have not looked into making this work with the automatically bundled versions of React & ReactDOM if LoadReact is set to true.

For anyone else looking to make this work:
To make the js code run server-side you have to change the import of ```react-dom/server``` to instead be 
```eact-dom-server-legacy.browser.production.min.js``` or ```react-dom/cjs/react-dom-server-legacy.browser.development``` since the new server-renderer uses classes 
that do not exist in the .net JS environment and instantly crashes.

The globally exposed window.ReactDOM object on the clientside should be imported from react-dom/client instead of react-dom