### PR TITLE
Fix minor typo in ASP.NET Core tutorials

### DIFF
--- a/site/jekyll/tutorials/aspnetcore.md
+++ b/site/jekyll/tutorials/aspnetcore.md
@@ -149,7 +149,7 @@ app.UseReact(config =>
   //  .AddScript("~/js/First.jsx")
   //  .AddScript("~/js/Second.jsx");
 
-  // If you use an external build too (for example, Babel, Webpack,
+  // If you use an external build tool (for example, Babel, Webpack,
   // Browserify or Gulp), you can improve performance by disabling
   // ReactJS.NET's version of Babel and loading the pre-transpiled
   // scripts. Example:

--- a/src/React.Template/reactnet-vanilla/Startup.cs
+++ b/src/React.Template/reactnet-vanilla/Startup.cs
@@ -72,7 +72,7 @@ namespace ReactDemo
 						ContractResolver = new CamelCasePropertyNamesContractResolver()
 					});
 
-				// If you use an external build too (for example, Babel, Webpack,
+				// If you use an external build tool (for example, Babel, Webpack,
 				// Browserify or Gulp), you can improve performance by disabling
 				// ReactJS.NET's version of Babel and loading the pre-transpiled
 				// scripts. Example:


### PR DESCRIPTION
Found a one-character typo while browsing the docs. Please feel free to close/modify this PR if you believe this change is not needed. Thank you.